### PR TITLE
chore: getter should not have prefix 'get_'

### DIFF
--- a/src/common/remote/conn.rs
+++ b/src/common/remote/conn.rs
@@ -79,12 +79,12 @@ impl Connection {
                 let resp_payload = client.request(&req_payload)?;
                 let server_check_response = payload_helper::build_server_response(resp_payload)?;
                 let conn_id = server_check_response
-                    .get_connection_id()
+                    .connection_id()
                     .ok_or(crate::api::error::Error::ClientShutdown(format!(
                         "Get connection_id failed,error_code={},message={}",
-                        server_check_response.get_error_code(),
+                        server_check_response.error_code(),
                         server_check_response
-                            .get_message()
+                            .message()
                             .or(Some(&"".to_string()))
                             .unwrap(),
                     )))?
@@ -231,9 +231,7 @@ mod tests {
             let de = ClientDetectionServerRequest::from(payload_inner.body_str.as_str());
             let de = de.headers(payload_inner.headers);
             remote_connect
-                .reply_client_resp(ClientDetectionClientResponse::new(
-                    de.get_request_id().clone(),
-                ))
+                .reply_client_resp(ClientDetectionClientResponse::new(de.request_id().clone()))
                 .await;
         }
     }

--- a/src/common/remote/remote_client.rs
+++ b/src/common/remote/remote_client.rs
@@ -37,15 +37,13 @@ impl GrpcRemoteClient {
             let de = ClientDetectionServerRequest::from(payload_inner.body_str.as_str());
             let de = de.headers(payload_inner.headers);
             self.connection
-                .reply_client_resp(ClientDetectionClientResponse::new(
-                    de.get_request_id().clone(),
-                ))
+                .reply_client_resp(ClientDetectionClientResponse::new(de.request_id().clone()))
                 .await;
         } else if TYPE_CONNECT_RESET_SERVER_REQUEST.eq(&payload_inner.type_url) {
             let de = ConnectResetServerRequest::from(payload_inner.body_str.as_str());
             let de = de.headers(payload_inner.headers);
             self.connection
-                .reply_client_resp(ConnectResetClientResponse::new(de.get_request_id().clone()))
+                .reply_client_resp(ConnectResetClientResponse::new(de.request_id().clone()))
                 .await;
         } else {
             // publish a server_req_payload, conn_server_req_payload_rx receive it once.

--- a/src/common/remote/request/client_request.rs
+++ b/src/common/remote/request/client_request.rs
@@ -6,18 +6,18 @@ use std::collections::HashMap;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct ServerCheckClientRequest {
     requestId: String,
-    /// count be empty.
+    /// could be empty.
     headers: HashMap<String, String>,
 }
 
 impl Request for ServerCheckClientRequest {
-    fn get_request_id(&self) -> &String {
+    fn request_id(&self) -> &String {
         &self.requestId
     }
-    fn get_headers(&self) -> &HashMap<String, String> {
+    fn headers(&self) -> &HashMap<String, String> {
         &self.headers
     }
-    fn get_type_url(&self) -> &String {
+    fn type_url(&self) -> &String {
         &TYPE_SERVER_CHECK_CLIENT_REQUEST
     }
 }
@@ -34,22 +34,21 @@ impl ServerCheckClientRequest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct ConnectionSetupClientRequest {
     requestId: String,
-    /// count be empty.
+    /// could be empty.
     headers: HashMap<String, String>,
     clientVersion: String,
     tenant: String,
-    /// count be empty.
     labels: HashMap<String, String>,
 }
 
 impl Request for ConnectionSetupClientRequest {
-    fn get_request_id(&self) -> &String {
+    fn request_id(&self) -> &String {
         &self.requestId
     }
-    fn get_headers(&self) -> &HashMap<String, String> {
+    fn headers(&self) -> &HashMap<String, String> {
         &self.headers
     }
-    fn get_type_url(&self) -> &String {
+    fn type_url(&self) -> &String {
         &TYPE_CONNECT_SETUP_CLIENT_REQUEST
     }
 }
@@ -75,18 +74,18 @@ impl ConnectionSetupClientRequest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct HealthCheckClientRequest {
     requestId: String,
-    /// count be empty.
+    /// could be empty.
     headers: HashMap<String, String>,
 }
 
 impl Request for HealthCheckClientRequest {
-    fn get_request_id(&self) -> &String {
+    fn request_id(&self) -> &String {
         &self.requestId
     }
-    fn get_headers(&self) -> &HashMap<String, String> {
+    fn headers(&self) -> &HashMap<String, String> {
         &self.headers
     }
-    fn get_type_url(&self) -> &String {
+    fn type_url(&self) -> &String {
         &TYPE_HEALTH_CHECK_CLIENT_REQUEST
     }
 }

--- a/src/common/remote/request/mod.rs
+++ b/src/common/remote/request/mod.rs
@@ -6,9 +6,9 @@ pub(crate) mod client_request;
 pub(crate) mod server_request;
 
 pub(crate) trait Request {
-    fn get_request_id(&self) -> &String;
-    fn get_headers(&self) -> &HashMap<String, String>;
-    fn get_type_url(&self) -> &String;
+    fn request_id(&self) -> &String;
+    fn headers(&self) -> &HashMap<String, String>;
+    fn type_url(&self) -> &String;
 }
 
 lazy_static! {

--- a/src/common/remote/request/server_request.rs
+++ b/src/common/remote/request/server_request.rs
@@ -6,20 +6,20 @@ use std::collections::HashMap;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct ConnectResetServerRequest {
     requestId: String,
-    /// count be empty.
+    /// could be empty.
     headers: HashMap<String, String>,
     serverIp: Option<String>,
     serverPort: Option<String>,
 }
 
 impl Request for ConnectResetServerRequest {
-    fn get_request_id(&self) -> &String {
+    fn request_id(&self) -> &String {
         &self.requestId
     }
-    fn get_headers(&self) -> &HashMap<String, String> {
+    fn headers(&self) -> &HashMap<String, String> {
         &self.headers
     }
-    fn get_type_url(&self) -> &String {
+    fn type_url(&self) -> &String {
         &TYPE_CONNECT_RESET_SERVER_REQUEST
     }
 }
@@ -50,18 +50,18 @@ impl From<&str> for ConnectResetServerRequest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct ClientDetectionServerRequest {
     requestId: String,
-    /// count be empty.
+    /// could be empty.
     headers: HashMap<String, String>,
 }
 
 impl Request for ClientDetectionServerRequest {
-    fn get_request_id(&self) -> &String {
+    fn request_id(&self) -> &String {
         &self.requestId
     }
-    fn get_headers(&self) -> &HashMap<String, String> {
+    fn headers(&self) -> &HashMap<String, String> {
         &self.headers
     }
-    fn get_type_url(&self) -> &String {
+    fn type_url(&self) -> &String {
         &TYPE_CLIENT_DETECTION_SERVER_REQUEST
     }
 }

--- a/src/common/remote/response/client_response.rs
+++ b/src/common/remote/response/client_response.rs
@@ -15,19 +15,19 @@ impl Response for ConnectResetClientResponse {
         ResponseCode::Ok == self.resultCode
     }
 
-    fn get_request_id(&self) -> Option<&String> {
+    fn request_id(&self) -> Option<&String> {
         Option::from(&self.requestId)
     }
 
-    fn get_message(&self) -> Option<&String> {
+    fn message(&self) -> Option<&String> {
         Option::from(&self.message)
     }
 
-    fn get_error_code(&self) -> u32 {
+    fn error_code(&self) -> u32 {
         self.errorCode
     }
 
-    fn get_type_url(&self) -> &String {
+    fn type_url(&self) -> &String {
         &TYPE_CONNECT_RESET_CLIENT_RESPONSE
     }
 }
@@ -56,19 +56,19 @@ impl Response for ClientDetectionClientResponse {
         ResponseCode::Ok == self.resultCode
     }
 
-    fn get_request_id(&self) -> Option<&String> {
+    fn request_id(&self) -> Option<&String> {
         Option::from(&self.requestId)
     }
 
-    fn get_message(&self) -> Option<&String> {
+    fn message(&self) -> Option<&String> {
         Option::from(&self.message)
     }
 
-    fn get_error_code(&self) -> u32 {
+    fn error_code(&self) -> u32 {
         self.errorCode
     }
 
-    fn get_type_url(&self) -> &String {
+    fn type_url(&self) -> &String {
         &TYPE_CLIENT_DETECTION_CLIENT_RESPONSE
     }
 }

--- a/src/common/remote/response/mod.rs
+++ b/src/common/remote/response/mod.rs
@@ -5,13 +5,13 @@ pub(crate) mod server_response;
 
 pub(crate) trait Response {
     fn is_success(&self) -> bool;
-    fn get_connection_id(&self) -> Option<&String> {
+    fn connection_id(&self) -> Option<&String> {
         None
     }
-    fn get_request_id(&self) -> Option<&String>;
-    fn get_message(&self) -> Option<&String>;
-    fn get_error_code(&self) -> u32;
-    fn get_type_url(&self) -> &String;
+    fn request_id(&self) -> Option<&String>;
+    fn message(&self) -> Option<&String>;
+    fn error_code(&self) -> u32;
+    fn type_url(&self) -> &String;
 }
 
 #[derive(Debug, Clone, PartialEq, serde_repr::Serialize_repr, serde_repr::Deserialize_repr)]

--- a/src/common/remote/response/server_response.rs
+++ b/src/common/remote/response/server_response.rs
@@ -17,23 +17,23 @@ impl Response for ServerCheckServerResponse {
         ResponseCode::Ok == self.resultCode
     }
 
-    fn get_connection_id(&self) -> Option<&String> {
+    fn connection_id(&self) -> Option<&String> {
         Option::from(&self.connectionId)
     }
 
-    fn get_request_id(&self) -> Option<&String> {
+    fn request_id(&self) -> Option<&String> {
         Option::from(&self.requestId)
     }
 
-    fn get_message(&self) -> Option<&String> {
+    fn message(&self) -> Option<&String> {
         Option::from(&self.message)
     }
 
-    fn get_error_code(&self) -> u32 {
+    fn error_code(&self) -> u32 {
         self.errorCode
     }
 
-    fn get_type_url(&self) -> &String {
+    fn type_url(&self) -> &String {
         &TYPE_SERVER_CHECK_SERVER_RESPONSE
     }
 }
@@ -63,19 +63,19 @@ impl Response for ErrorResponse {
         ResponseCode::Ok == self.resultCode
     }
 
-    fn get_request_id(&self) -> Option<&String> {
+    fn request_id(&self) -> Option<&String> {
         Option::from(&self.requestId)
     }
 
-    fn get_message(&self) -> Option<&String> {
+    fn message(&self) -> Option<&String> {
         Option::from(&self.message)
     }
 
-    fn get_error_code(&self) -> u32 {
+    fn error_code(&self) -> u32 {
         self.errorCode
     }
 
-    fn get_type_url(&self) -> &String {
+    fn type_url(&self) -> &String {
         &TYPE_ERROR_SERVER_RESPONSE
     }
 }
@@ -104,19 +104,19 @@ impl Response for HealthCheckServerResponse {
         ResponseCode::Ok == self.resultCode
     }
 
-    fn get_request_id(&self) -> Option<&String> {
+    fn request_id(&self) -> Option<&String> {
         Option::from(&self.requestId)
     }
 
-    fn get_message(&self) -> Option<&String> {
+    fn message(&self) -> Option<&String> {
         Option::from(&self.message)
     }
 
-    fn get_error_code(&self) -> u32 {
+    fn error_code(&self) -> u32 {
         self.errorCode
     }
 
-    fn get_type_url(&self) -> &String {
+    fn type_url(&self) -> &String {
         &TYPE_HEALTH_CHECK_SERVER_RESPONSE
     }
 }

--- a/src/config/client_request.rs
+++ b/src/config/client_request.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct ConfigBatchListenClientRequest {
     requestId: String,
-    /// count be empty.
+    /// could be empty.
     headers: HashMap<String, String>,
     /// listen or remove-listen.
     listen: bool,
@@ -15,13 +15,13 @@ pub(crate) struct ConfigBatchListenClientRequest {
 }
 
 impl Request for ConfigBatchListenClientRequest {
-    fn get_request_id(&self) -> &String {
+    fn request_id(&self) -> &String {
         &self.requestId
     }
-    fn get_headers(&self) -> &HashMap<String, String> {
+    fn headers(&self) -> &HashMap<String, String> {
         &self.headers
     }
-    fn get_type_url(&self) -> &String {
+    fn type_url(&self) -> &String {
         &TYPE_CONFIG_BATCH_LISTEN_CLIENT_REQUEST
     }
 }
@@ -76,7 +76,7 @@ impl ConfigListenContext {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct ConfigQueryClientRequest {
     requestId: String,
-    /// count be empty.
+    /// could be empty.
     headers: HashMap<String, String>,
     /// DataId
     dataId: String,
@@ -87,13 +87,13 @@ pub(crate) struct ConfigQueryClientRequest {
 }
 
 impl Request for ConfigQueryClientRequest {
-    fn get_request_id(&self) -> &String {
+    fn request_id(&self) -> &String {
         &self.requestId
     }
-    fn get_headers(&self) -> &HashMap<String, String> {
+    fn headers(&self) -> &HashMap<String, String> {
         &self.headers
     }
-    fn get_type_url(&self) -> &String {
+    fn type_url(&self) -> &String {
         &TYPE_CONFIG_QUERY_CLIENT_REQUEST
     }
 }

--- a/src/config/client_response.rs
+++ b/src/config/client_response.rs
@@ -15,19 +15,19 @@ impl Response for ConfigChangeNotifyClientResponse {
         ResponseCode::Ok == self.resultCode
     }
 
-    fn get_request_id(&self) -> Option<&String> {
+    fn request_id(&self) -> Option<&String> {
         Option::from(&self.requestId)
     }
 
-    fn get_message(&self) -> Option<&String> {
+    fn message(&self) -> Option<&String> {
         Option::from(&self.message)
     }
 
-    fn get_error_code(&self) -> u32 {
+    fn error_code(&self) -> u32 {
         self.errorCode
     }
 
-    fn get_type_url(&self) -> &String {
+    fn type_url(&self) -> &String {
         &TYPE_CONFIG_CHANGE_NOTIFY_CLIENT_RESPONSE
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -62,10 +62,10 @@ impl NacosConfigService {
                                 let payload_inner = payload_helper::covert_payload(server_req_payload);
                                 if TYPE_CLIENT_DETECTION_SERVER_REQUEST.eq(&payload_inner.type_url) {
                                     let de = ClientDetectionServerRequest::from(payload_inner.body_str.as_str()).headers(payload_inner.headers);
-                                    conn.reply_client_resp(ClientDetectionClientResponse::new(de.get_request_id().clone())).await;
+                                    conn.reply_client_resp(ClientDetectionClientResponse::new(de.request_id().clone())).await;
                                 } else if TYPE_CONNECT_RESET_SERVER_REQUEST.eq(&payload_inner.type_url) {
                                     let de = ConnectResetServerRequest::from(payload_inner.body_str.as_str()).headers(payload_inner.headers);
-                                    conn.reply_client_resp(ConnectResetClientResponse::new(de.get_request_id().clone())).await;
+                                    conn.reply_client_resp(ConnectResetClientResponse::new(de.request_id().clone())).await;
                                     // todo reset connection
                                 } else {
                                     // publish a server_req_payload, server_req_payload_rx receive it once.
@@ -96,7 +96,7 @@ impl NacosConfigService {
         if TYPE_CONFIG_CHANGE_NOTIFY_SERVER_REQUEST.eq(&payload_inner.type_url) {
             let server_req = ConfigChangeNotifyServerRequest::from(payload_inner.body_str.as_str())
                 .headers(payload_inner.headers);
-            let server_req_id = server_req.get_request_id().clone();
+            let server_req_id = server_req.request_id().clone();
             let req_tenant = server_req.tenant.or(Some("".to_string())).unwrap();
             tracing::info!(
                 "receiver config change, dataId={},group={},namespace={}",
@@ -135,7 +135,7 @@ impl ConfigService for NacosConfigService {
         let resp = self.connection.get_client()?.request(&req_payload)?;
         let payload_inner = payload_helper::covert_payload(resp);
         let config_resp = ConfigQueryServerResponse::from(payload_inner.body_str.as_str());
-        Ok(String::from(config_resp.get_content()))
+        Ok(String::from(config_resp.content()))
     }
 
     fn add_listener(

--- a/src/config/server_request.rs
+++ b/src/config/server_request.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct ConfigChangeNotifyServerRequest {
     requestId: String,
-    /// count be empty.
+    /// could be empty.
     headers: HashMap<String, String>,
     pub(crate) dataId: String,
     pub(crate) group: String,
@@ -15,13 +15,13 @@ pub(crate) struct ConfigChangeNotifyServerRequest {
 }
 
 impl Request for ConfigChangeNotifyServerRequest {
-    fn get_request_id(&self) -> &String {
+    fn request_id(&self) -> &String {
         &self.requestId
     }
-    fn get_headers(&self) -> &HashMap<String, String> {
+    fn headers(&self) -> &HashMap<String, String> {
         &self.headers
     }
-    fn get_type_url(&self) -> &String {
+    fn type_url(&self) -> &String {
         &TYPE_CONFIG_CHANGE_NOTIFY_SERVER_REQUEST
     }
 }

--- a/src/config/server_response.rs
+++ b/src/config/server_response.rs
@@ -16,19 +16,19 @@ impl Response for ConfigChangeBatchListenServerResponse {
         ResponseCode::Ok == self.resultCode
     }
 
-    fn get_request_id(&self) -> Option<&String> {
+    fn request_id(&self) -> Option<&String> {
         Option::from(&self.requestId)
     }
 
-    fn get_message(&self) -> Option<&String> {
+    fn message(&self) -> Option<&String> {
         Option::from(&self.message)
     }
 
-    fn get_error_code(&self) -> u32 {
+    fn error_code(&self) -> u32 {
         self.errorCode
     }
 
-    fn get_type_url(&self) -> &String {
+    fn type_url(&self) -> &String {
         &TYPE_CONFIG_CHANGE_BATCH_LISTEN_RESPONSE
     }
 }
@@ -44,7 +44,7 @@ impl ConfigChangeBatchListenServerResponse {
         }
     }
 
-    pub fn get_changed_configs(&self) -> Option<&Vec<ConfigContext>> {
+    pub fn changed_configs(&self) -> Option<&Vec<ConfigContext>> {
         Option::from(&self.changedConfigs)
     }
 }
@@ -88,19 +88,19 @@ impl Response for ConfigQueryServerResponse {
         ResponseCode::Ok == self.resultCode
     }
 
-    fn get_request_id(&self) -> Option<&String> {
+    fn request_id(&self) -> Option<&String> {
         Option::from(&self.requestId)
     }
 
-    fn get_message(&self) -> Option<&String> {
+    fn message(&self) -> Option<&String> {
         Option::from(&self.message)
     }
 
-    fn get_error_code(&self) -> u32 {
+    fn error_code(&self) -> u32 {
         self.errorCode
     }
 
-    fn get_type_url(&self) -> &String {
+    fn type_url(&self) -> &String {
         &TYPE_CONFIG_CHANGE_BATCH_LISTEN_RESPONSE
     }
 }
@@ -112,16 +112,16 @@ impl ConfigQueryServerResponse {
     pub(crate) fn is_query_conflict(&self) -> bool {
         self.errorCode == CONFIG_QUERY_CONFLICT
     }
-    pub fn get_content_type(&self) -> &String {
+    pub fn content_type(&self) -> &String {
         &self.contentType
     }
-    pub fn get_content(&self) -> &String {
+    pub fn content(&self) -> &String {
         &self.content
     }
-    pub fn get_md5(&self) -> &String {
+    pub fn md5(&self) -> &String {
         &self.md5
     }
-    pub fn get_encrypted_Data_Key(&self) -> Option<&String> {
+    pub fn encrypted_Data_Key(&self) -> Option<&String> {
         Option::from(&self.encryptedDataKey)
     }
 }


### PR DESCRIPTION
Rust 惯例命名规范，获取属性的方法不要用 'get_' 前缀，所以都去掉。

参考：[https://course.rs/practice/naming.html#读访问器(Getter)的名称遵循 Rust 的命名规范(C-GETTER)](https://course.rs/practice/naming.html#%E8%AF%BB%E8%AE%BF%E9%97%AE%E5%99%A8getter%E7%9A%84%E5%90%8D%E7%A7%B0%E9%81%B5%E5%BE%AA-rust-%E7%9A%84%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83c-getter)