### PR TITLE
Refactor: config listener basically available.

### DIFF
--- a/examples/simple_app.rs
+++ b/examples/simple_app.rs
@@ -1,3 +1,4 @@
+use nacos_client::api::client_config::ClientConfig;
 use nacos_client::api::config::ConfigService;
 use nacos_client::api::config::ConfigServiceBuilder;
 use std::time::Duration;
@@ -12,7 +13,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // sets this to be the default, global collector for this application.
         .init();
 
-    let mut config_service = ConfigServiceBuilder::default().build().await;
+    let mut config_service = ConfigServiceBuilder::new(
+        ClientConfig::new()
+            .server_addr("0.0.0.0:9848")
+            // Attention! "public" is ""
+            .namespace("")
+            .app_name("simple_app"),
+    )
+    .build()
+    .await;
     let config =
         config_service.get_config("hongwen.properties".to_string(), "LOVE".to_string(), 3000);
     match config {
@@ -28,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
     match _listen {
-        Ok(_) => tracing::info!("listening the config"),
+        Ok(_) => tracing::info!("listening the config success"),
         Err(err) => tracing::error!("listen config error {:?}", err),
     }
 

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -1,5 +1,6 @@
 use crate::api::{client_config, error};
 
+/// Trait or Closure? Please refer to more sdk before deciding.
 pub(crate) type ConfigChangeListener = dyn Fn(ConfigResponse) + Send + Sync;
 
 pub trait ConfigService {
@@ -78,19 +79,19 @@ impl ConfigResponse {
         }
     }
 
-    pub fn get_namespace(&self) -> &String {
+    pub fn namespace(&self) -> &String {
         &self.namespace
     }
-    pub fn get_data_id(&self) -> &String {
+    pub fn data_id(&self) -> &String {
         &self.data_id
     }
-    pub fn get_group(&self) -> &String {
+    pub fn group(&self) -> &String {
         &self.group
     }
-    pub fn get_content(&self) -> &String {
+    pub fn content(&self) -> &String {
         &self.content
     }
-    pub fn get_content_type(&self) -> &String {
+    pub fn content_type(&self) -> &String {
         &self.content_type
     }
 }
@@ -144,7 +145,7 @@ mod tests {
             "hongwen.properties".to_string(),
             "LOVE".to_string(),
             Box::new(|config_resp| {
-                tracing::info!("listen the config {}", config_resp.get_content());
+                tracing::info!("listen the config {}", config_resp.content());
             }),
         );
         match _listen {

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -27,6 +27,9 @@ pub enum Error {
     #[error("Deserialization failed: {0}")]
     Deserialization(String),
 
+    #[error("get result failed: {0}")]
+    ErrResult(String),
+
     #[error("remote client shutdown failed: {0}")]
     ClientShutdown(String),
 

--- a/src/common/remote/response/server_response.rs
+++ b/src/common/remote/response/server_response.rs
@@ -91,6 +91,13 @@ impl ErrorResponse {
     }
 }
 
+impl From<&str> for ErrorResponse {
+    fn from(json_str: &str) -> Self {
+        let de: serde_json::Result<Self> = serde_json::from_str(json_str);
+        de.unwrap()
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct HealthCheckServerResponse {
     requestId: Option<String>,

--- a/src/common/util/payload_helper.rs
+++ b/src/common/util/payload_helper.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 
 /// Payload Inner Model
+#[derive(Debug)]
 pub(crate) struct PayloadInner {
     /// The data type of `body_str`
     pub(crate) type_url: String,
@@ -114,6 +115,11 @@ pub(crate) fn covert_payload(payload: Payload) -> PayloadInner {
         headers,
         body_str,
     }
+}
+
+/// Whether ErrorResponse.
+pub(crate) fn is_err_resp(type_trl: &String) -> bool {
+    return TYPE_ERROR_SERVER_RESPONSE.eq(type_trl);
 }
 
 #[cfg(test)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,123 +7,26 @@ mod worker;
 
 use crate::api::client_config::ClientConfig;
 use crate::api::config::ConfigService;
-use crate::common::remote::conn::Connection;
-use crate::common::remote::request::server_request::*;
-use crate::common::remote::request::*;
-use crate::common::remote::response::client_response::*;
-use crate::common::remote::response::server_response::*;
-use crate::common::remote::response::*;
-use crate::common::util::payload_helper;
-use crate::common::util::payload_helper::PayloadInner;
-use crate::config::client_request::*;
-use crate::config::client_response::*;
-use crate::config::server_request::*;
-use crate::config::server_response::*;
 use crate::config::worker::ConfigWorker;
 
 pub(crate) struct NacosConfigService {
     client_config: ClientConfig,
-    connection: Connection,
     /// config client worker
     client_worker: ConfigWorker,
 }
 
 impl NacosConfigService {
     pub fn new(client_config: ClientConfig) -> Self {
-        let connection = Connection::new(client_config.clone());
         let client_worker = ConfigWorker::new(client_config.clone());
         Self {
             client_config,
-            connection,
             client_worker,
         }
     }
 
     /// start Once
     pub(crate) async fn start(&mut self) {
-        self.connection.connect().await;
-
-        let mut conn = self.connection.clone();
-        let mut client_worker = self.client_worker.clone();
-
-        let _conn_thread = std::thread::Builder::new()
-            .name("config-remote-client".into())
-            .spawn(|| {
-                let runtime = tokio::runtime::Builder::new_current_thread()
-                    .enable_io()
-                    .enable_time()
-                    .build()
-                    .expect("config-remote-client runtime initialization failed");
-
-                runtime.block_on(async move {
-                    let (server_req_payload_tx, mut server_req_payload_rx) = tokio::sync::mpsc::channel(128);
-                    loop {
-                        tokio::select! { biased;
-                            // deal with next_server_req_payload, basic conn interaction logic.
-                            server_req_payload_inner = conn.next_server_req_payload() => {
-                                let payload_inner = server_req_payload_inner;
-                                if TYPE_CLIENT_DETECTION_SERVER_REQUEST.eq(&payload_inner.type_url) {
-                                    let de = ClientDetectionServerRequest::from(payload_inner.body_str.as_str()).headers(payload_inner.headers);
-                                    let _ = conn.reply_client_resp(ClientDetectionClientResponse::new(de.request_id().clone())).await;
-                                } else if TYPE_CONNECT_RESET_SERVER_REQUEST.eq(&payload_inner.type_url) {
-                                    let de = ConnectResetServerRequest::from(payload_inner.body_str.as_str()).headers(payload_inner.headers);
-                                    let _ = conn.reply_client_resp(ConnectResetClientResponse::new(de.request_id().clone())).await;
-                                    // todo reset connection
-                                } else {
-                                    // publish a server_req_payload, server_req_payload_rx receive it once.
-                                    if let Err(_) = server_req_payload_tx.send(payload_inner).await {
-                                        tracing::error!("receiver dropped")
-                                    }
-                                }
-                            },
-                            // receive a server_req from server_req_payload_tx
-                            receive_server_req = server_req_payload_rx.recv() => {
-                                Self::deal_extra_server_req(&mut client_worker, &mut conn, receive_server_req.unwrap()).await
-                            },
-                        }
-                    }
-                });
-            })
-            .expect("config-remote-client could not spawn thread");
-
-        // sleep 6ms, Make sure the link is established.
-        tokio::time::sleep(std::time::Duration::from_millis(6)).await
-    }
-
-    async fn deal_extra_server_req(
-        client_worker: &mut ConfigWorker,
-        conn: &mut Connection,
-        payload_inner: PayloadInner,
-    ) {
-        if TYPE_CONFIG_CHANGE_NOTIFY_SERVER_REQUEST.eq(&payload_inner.type_url) {
-            let server_req = ConfigChangeNotifyServerRequest::from(payload_inner.body_str.as_str())
-                .headers(payload_inner.headers);
-            let server_req_id = server_req.request_id().clone();
-            let req_tenant = server_req.tenant.or(Some("".to_string())).unwrap();
-            tracing::info!(
-                "receiver config change, dataId={},group={},namespace={}",
-                &server_req.dataId,
-                &server_req.group,
-                req_tenant.clone()
-            );
-            // notify config change
-            client_worker
-                .notify_config_change(
-                    server_req.dataId.to_string(),
-                    server_req.group.to_string(),
-                    req_tenant.clone(),
-                )
-                .await;
-            // reply ConfigChangeNotifyClientResponse for ConfigChangeNotifyServerRequest
-            let _ = conn
-                .reply_client_resp(ConfigChangeNotifyClientResponse::new(server_req_id))
-                .await;
-        } else {
-            tracing::warn!(
-                "unknown receive type_url={}, maybe sdk have to upgrade!",
-                &payload_inner.type_url
-            );
-        }
+        self.client_worker.start().await;
     }
 }
 
@@ -134,22 +37,7 @@ impl ConfigService for NacosConfigService {
         group: String,
         _timeout_ms: u64,
     ) -> crate::api::error::Result<String> {
-        let tenant = self.client_config.namespace.clone();
-        let req = ConfigQueryClientRequest::new(data_id, group, tenant);
-        let req_payload = payload_helper::build_req_grpc_payload(req);
-        let resp = self.connection.get_client()?.request(&req_payload)?;
-        let payload_inner = payload_helper::covert_payload(resp);
-        // return Err if get a err_resp
-        if payload_helper::is_err_resp(&payload_inner.type_url) {
-            let err_resp = ErrorResponse::from(payload_inner.body_str.as_str());
-            return Err(crate::api::error::Error::ErrResult(format!(
-                "error_code={},message={}",
-                err_resp.error_code(),
-                err_resp.message().unwrap()
-            )));
-        }
-        let config_resp = ConfigQueryServerResponse::from(payload_inner.body_str.as_str());
-        Ok(String::from(config_resp.content()))
+        return self.client_worker.get_config(data_id, group, _timeout_ms);
     }
 
     fn add_listener(
@@ -164,17 +52,6 @@ impl ConfigService for NacosConfigService {
             self.client_config.namespace.clone(),
             listener,
         );
-        // todo 抽离到统一的发起地方，并取得结果
-        let req = ConfigBatchListenClientRequest::new(true).add_config_listen_context(
-            ConfigListenContext::new(
-                data_id.clone(),
-                group.clone(),
-                self.client_config.namespace.clone(),
-                String::from(""),
-            ),
-        );
-        let req_payload = payload_helper::build_req_grpc_payload(req);
-        let _resp_payload = self.connection.get_client()?.request(&req_payload)?;
         Ok(())
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -107,11 +107,13 @@ impl NacosConfigService {
                 req_tenant.clone()
             );
             // notify config change
-            client_worker.notify_config_change(
-                server_req.dataId.to_string(),
-                server_req.group.to_string(),
-                req_tenant.clone(),
-            );
+            client_worker
+                .notify_config_change(
+                    server_req.dataId.to_string(),
+                    server_req.group.to_string(),
+                    req_tenant.clone(),
+                )
+                .await;
             // reply ConfigChangeNotifyClientResponse for ConfigChangeNotifyServerRequest
             let _ = conn
                 .reply_client_resp(ConfigChangeNotifyClientResponse::new(server_req_id))
@@ -207,7 +209,7 @@ mod tests {
             "hongwen.properties".to_string(),
             "LOVE".to_string(),
             Box::new(|config_resp| {
-                tracing::info!("listen the config {}", config_resp.get_content());
+                tracing::info!("listen the config {}", config_resp.content());
             }),
         );
         match _listen {

--- a/src/config/server_response.rs
+++ b/src/config/server_response.rs
@@ -49,6 +49,13 @@ impl ConfigChangeBatchListenServerResponse {
     }
 }
 
+impl From<&str> for ConfigChangeBatchListenServerResponse {
+    fn from(json_str: &str) -> Self {
+        let de: serde_json::Result<Self> = serde_json::from_str(json_str);
+        de.unwrap()
+    }
+}
+
 /// The Context of config changed.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct ConfigContext {

--- a/src/config/server_response.rs
+++ b/src/config/server_response.rs
@@ -124,6 +124,9 @@ impl ConfigQueryServerResponse {
     pub fn encrypted_Data_Key(&self) -> Option<&String> {
         Option::from(&self.encryptedDataKey)
     }
+    pub fn last_modified(&self) -> i64 {
+        self.lastModified
+    }
 }
 
 impl From<&str> for ConfigQueryServerResponse {

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -1,6 +1,7 @@
-const GROUP_KEY_SPLIT: &str = "+";
+/// A special splitter that reduces user-defined character repetition.
+const GROUP_KEY_SPLIT: &str = "+_+";
 
-/// group to data_id '+' group '+' tenant
+/// group to data_id '+_+' group '+_+' tenant
 pub(crate) fn group_key(data_id: &String, group: &String, tenant: &String) -> String {
     "".to_string()
         + data_id.as_str()

--- a/src/config/worker.rs
+++ b/src/config/worker.rs
@@ -1,5 +1,17 @@
 use crate::api::client_config::ClientConfig;
 use crate::api::config::ConfigResponse;
+use crate::common::remote::conn::Connection;
+use crate::common::remote::request::server_request::*;
+use crate::common::remote::request::*;
+use crate::common::remote::response::client_response::*;
+use crate::common::remote::response::server_response::*;
+use crate::common::remote::response::*;
+use crate::common::util::payload_helper;
+use crate::common::util::payload_helper::PayloadInner;
+use crate::config::client_request::*;
+use crate::config::client_response::*;
+use crate::config::server_request::*;
+use crate::config::server_response::*;
 use crate::config::util;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -7,67 +19,94 @@ use std::sync::{Arc, Mutex};
 #[derive(Clone)]
 pub(crate) struct ConfigWorker {
     client_config: ClientConfig,
+    connection: Connection,
     cache_data_map: Arc<Mutex<HashMap<String, CacheData>>>,
-    /// group_key: String
-    notify_change_tx: tokio::sync::mpsc::Sender<String>,
 }
 
 impl ConfigWorker {
     pub(crate) fn new(client_config: ClientConfig) -> Self {
+        let connection = Connection::new(client_config.clone());
         let cache_data_map = Arc::new(Mutex::new(HashMap::new()));
-        let clone_cache_data = Arc::clone(&cache_data_map);
+
+        Self {
+            client_config,
+            connection,
+            cache_data_map,
+        }
+    }
+
+    /// start Once
+    pub(crate) async fn start(&mut self) {
+        self.connection.connect().await;
+
+        let mut conn = self.connection.clone();
+        // group_key: String
         let (notify_change_tx, notify_change_rx) = tokio::sync::mpsc::channel(16);
 
-        tokio::spawn(Self::list_ensure_cache_data_newest());
+        let _conn_thread = std::thread::Builder::new()
+            .name("config-remote-client".into())
+            .spawn(|| {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_io()
+                    .enable_time()
+                    .build()
+                    .expect("config-remote-client runtime initialization failed");
+
+                runtime.block_on(async move {
+                    let (server_req_payload_tx, mut server_req_payload_rx) = tokio::sync::mpsc::channel(128);
+                    loop {
+                        tokio::select! { biased;
+                            // deal with next_server_req_payload, basic conn interaction logic.
+                            server_req_payload_inner = conn.next_server_req_payload() => {
+                                let payload_inner = server_req_payload_inner;
+                                if TYPE_CLIENT_DETECTION_SERVER_REQUEST.eq(&payload_inner.type_url) {
+                                    let de = ClientDetectionServerRequest::from(payload_inner.body_str.as_str()).headers(payload_inner.headers);
+                                    let _ = conn.reply_client_resp(ClientDetectionClientResponse::new(de.request_id().clone())).await;
+                                } else if TYPE_CONNECT_RESET_SERVER_REQUEST.eq(&payload_inner.type_url) {
+                                    let de = ConnectResetServerRequest::from(payload_inner.body_str.as_str()).headers(payload_inner.headers);
+                                    let _ = conn.reply_client_resp(ConnectResetClientResponse::new(de.request_id().clone())).await;
+                                    // todo reset connection
+                                } else {
+                                    // publish a server_req_payload, server_req_payload_rx receive it once.
+                                    if let Err(_) = server_req_payload_tx.send(payload_inner).await {
+                                        tracing::error!("receiver dropped")
+                                    }
+                                }
+                            },
+                            // receive a server_req from server_req_payload_tx
+                            receive_server_req = server_req_payload_rx.recv() => {
+                                Self::deal_extra_server_req(notify_change_tx.clone(), &mut conn, receive_server_req.unwrap()).await
+                            },
+                        }
+                    }
+                });
+            })
+            .expect("config-remote-client could not spawn thread");
+
         tokio::spawn(Self::notify_change_to_cache_data(
-            clone_cache_data,
+            self.connection.clone(),
+            Arc::clone(&self.cache_data_map),
             notify_change_rx,
         ));
+        tokio::spawn(Self::list_ensure_cache_data_newest(
+            self.connection.clone(),
+            Arc::clone(&self.cache_data_map),
+        ));
 
-        let client_worker = Self {
-            client_config,
-            cache_data_map,
-            notify_change_tx,
-        };
-        client_worker
+        // sleep 6ms, Make sure the link is established.
+        tokio::time::sleep(std::time::Duration::from_millis(6)).await
     }
 
-    /// List-Watch, list ensure cache-data newest.
-    async fn list_ensure_cache_data_newest() {
-        loop {
-            // todo query from server
-            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
-        }
-    }
-
-    /// Notify change to cache_data.
-    async fn notify_change_to_cache_data(
-        cache_data_map: Arc<Mutex<HashMap<String, CacheData>>>,
-        mut notify_change_rx: tokio::sync::mpsc::Receiver<String>,
-    ) {
-        loop {
-            while let Some(group_key) = notify_change_rx.recv().await {
-                loop {
-                    let cache_lock = cache_data_map.try_lock();
-                    if let Ok(mut mutex) = cache_lock {
-                        if !mutex.contains_key(group_key.as_str()) {
-                            break;
-                        }
-                        let _ = mutex.get_mut(group_key.as_str()).map(|c| {
-                            // todo get the newest config to notify
-                            c.notify_listener(ConfigResponse::new(
-                                c.data_id.clone(),
-                                c.group.clone(),
-                                c.tenant.clone(),
-                                c.content.clone(),
-                                c.content_type.clone(),
-                            ))
-                        });
-                        break;
-                    }
-                }
-            }
-        }
+    pub(crate) fn get_config(
+        &mut self,
+        data_id: String,
+        group: String,
+        _timeout_ms: u64,
+    ) -> crate::api::error::Result<String> {
+        let tenant = self.client_config.namespace.clone();
+        let config_resp =
+            Self::get_config_inner(&mut self.connection, data_id, group, tenant, _timeout_ms);
+        Ok(String::from(config_resp?.content()))
     }
 
     /// Add listener.
@@ -83,10 +122,31 @@ impl ConfigWorker {
             let cache_lock = self.cache_data_map.try_lock();
             if let Ok(mut mutex) = cache_lock {
                 if !mutex.contains_key(group_key.as_str()) {
-                    mutex.insert(
-                        group_key.clone(),
-                        CacheData::new(data_id.clone(), group.clone(), tenant.clone()),
-                    );
+                    let mut cache_data =
+                        CacheData::new(data_id.clone(), group.clone(), tenant.clone());
+                    // listen immediately upon initialization
+                    if let Ok(client) = self.connection.get_client() {
+                        // init cache_data
+                        let config_resp = Self::get_config_inner(
+                            &mut self.connection,
+                            cache_data.data_id.clone(),
+                            cache_data.group.clone(),
+                            cache_data.tenant.clone(),
+                            3000,
+                        );
+                        if let Ok(config_resp) = config_resp {
+                            Self::fill_data_and_notify(&mut cache_data, config_resp);
+                        }
+                        let req = ConfigBatchListenClientRequest::new(true)
+                            .add_config_listen_context(ConfigListenContext::new(
+                                cache_data.data_id.clone(),
+                                cache_data.group.clone(),
+                                cache_data.tenant.clone(),
+                                cache_data.md5.clone(),
+                            ));
+                        let _ = client.request(&payload_helper::build_req_grpc_payload(req));
+                    }
+                    mutex.insert(group_key.clone(), cache_data);
                 }
                 let _ = mutex
                     .get_mut(group_key.as_str())
@@ -95,16 +155,139 @@ impl ConfigWorker {
             }
         }
     }
+}
 
-    /// notify config change
-    pub(crate) async fn notify_config_change(
-        &mut self,
+impl ConfigWorker {
+    async fn deal_extra_server_req(
+        notify_change_tx: tokio::sync::mpsc::Sender<String>,
+        conn: &mut Connection,
+        payload_inner: PayloadInner,
+    ) {
+        if TYPE_CONFIG_CHANGE_NOTIFY_SERVER_REQUEST.eq(&payload_inner.type_url) {
+            let server_req = ConfigChangeNotifyServerRequest::from(payload_inner.body_str.as_str())
+                .headers(payload_inner.headers);
+            let server_req_id = server_req.request_id().clone();
+            let req_tenant = server_req.tenant.or(Some("".to_string())).unwrap();
+            tracing::info!(
+                "receiver config change, dataId={},group={},namespace={}",
+                &server_req.dataId,
+                &server_req.group,
+                req_tenant.clone()
+            );
+            // notify config change
+            let group_key = util::group_key(&server_req.dataId, &server_req.group, &req_tenant);
+            let _ = notify_change_tx.send(group_key).await;
+            // reply ConfigChangeNotifyClientResponse for ConfigChangeNotifyServerRequest
+            let _ = conn
+                .reply_client_resp(ConfigChangeNotifyClientResponse::new(server_req_id))
+                .await;
+        } else {
+            tracing::warn!(
+                "unknown receive type_url={}, maybe sdk have to upgrade!",
+                &payload_inner.type_url
+            );
+        }
+    }
+
+    /// List-Watch, list ensure cache-data newest.
+    async fn list_ensure_cache_data_newest(
+        mut connection: Connection,
+        cache_data_map: Arc<Mutex<HashMap<String, CacheData>>>,
+    ) {
+        loop {
+            {
+                let cache_lock = cache_data_map.try_lock();
+                if let Ok(mutex) = cache_lock {
+                    let mut context_vec = Vec::with_capacity(mutex.len());
+                    for c in mutex.values() {
+                        context_vec.push(ConfigListenContext::new(
+                            c.data_id.clone(),
+                            c.group.clone(),
+                            c.tenant.clone(),
+                            c.md5.clone(),
+                        ));
+                    }
+                    let req = ConfigBatchListenClientRequest::new(true)
+                        .config_listen_context(context_vec);
+                    if let Ok(client) = connection.get_client() {
+                        let _ = client.request(&payload_helper::build_req_grpc_payload(req));
+                    }
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        }
+    }
+
+    /// Notify change to cache_data.
+    async fn notify_change_to_cache_data(
+        mut connection: Connection,
+        cache_data_map: Arc<Mutex<HashMap<String, CacheData>>>,
+        mut notify_change_rx: tokio::sync::mpsc::Receiver<String>,
+    ) {
+        loop {
+            while let Some(group_key) = notify_change_rx.recv().await {
+                loop {
+                    let cache_lock = cache_data_map.try_lock();
+                    if let Ok(mut mutex) = cache_lock {
+                        if !mutex.contains_key(group_key.as_str()) {
+                            break;
+                        }
+                        let _ = mutex.get_mut(group_key.as_str()).map(|c| {
+                            // get the newest config to notify
+                            let config_resp = Self::get_config_inner(
+                                &mut connection,
+                                c.data_id.clone(),
+                                c.group.clone(),
+                                c.tenant.clone(),
+                                3000,
+                            );
+                            if let Ok(config_resp) = config_resp {
+                                Self::fill_data_and_notify(c, config_resp);
+                            }
+                        });
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    fn fill_data_and_notify(cache_data: &mut CacheData, config_resp: ConfigQueryServerResponse) {
+        cache_data.content_type = config_resp.content_type().to_string();
+        cache_data.content = config_resp.content().to_string();
+        cache_data.md5 = config_resp.md5().to_string();
+        cache_data.last_modified = config_resp.last_modified();
+        cache_data.need_sync_server = false;
+        if cache_data.initializing {
+            cache_data.initializing = false;
+        } else {
+            // check md5 and then notify
+            cache_data.notify_listener();
+        }
+    }
+
+    fn get_config_inner(
+        connection: &mut Connection,
         data_id: String,
         group: String,
         tenant: String,
-    ) {
-        let group_key = util::group_key(&data_id, &group, &tenant);
-        let _ = self.notify_change_tx.send(group_key).await;
+        _timeout_ms: u64,
+    ) -> crate::api::error::Result<ConfigQueryServerResponse> {
+        let req = ConfigQueryClientRequest::new(data_id, group, tenant);
+        let req_payload = payload_helper::build_req_grpc_payload(req);
+        let resp = connection.get_client()?.request(&req_payload)?;
+        let payload_inner = payload_helper::covert_payload(resp);
+        // return Err if get a err_resp
+        if payload_helper::is_err_resp(&payload_inner.type_url) {
+            let err_resp = ErrorResponse::from(payload_inner.body_str.as_str());
+            return Err(crate::api::error::Error::ErrResult(format!(
+                "error_code={},message={}",
+                err_resp.error_code(),
+                err_resp.message().unwrap()
+            )));
+        }
+        let config_resp = ConfigQueryServerResponse::from(payload_inner.body_str.as_str());
+        Ok(config_resp)
     }
 }
 
@@ -155,18 +338,24 @@ impl CacheData {
         }
     }
 
-    /// Notify listener. when last_md5 not equals notify_md5
-    fn notify_listener(&mut self, config_response: ConfigResponse) {
+    /// Notify listener. when last-md5 not equals the-newest-md5
+    fn notify_listener(&mut self) {
         loop {
             let listen_lock = self.listeners.try_lock();
             if let Ok(mut mutex) = listen_lock {
                 for listen in mutex.iter_mut() {
-                    let notify_md5 = self.md5.clone();
-                    // Notify when last_md5 not equals notify_md5
-                    if listen.last_md5.ne(&notify_md5) {
-                        (listen.listener)(config_response.clone());
-                        listen.last_md5 = notify_md5.clone();
+                    if listen.last_md5.eq(&self.md5) {
+                        continue;
                     }
+                    // Notify when last-md5 not equals the-newest-md5
+                    (listen.listener)(ConfigResponse::new(
+                        self.data_id.clone(),
+                        self.group.clone(),
+                        self.tenant.clone(),
+                        self.content.clone(),
+                        self.content_type.clone(),
+                    ));
+                    listen.last_md5 = self.md5.clone();
                 }
                 break;
             }


### PR DESCRIPTION
issue #3 

[x] 实现配置内存缓存
[x] 完善监听逻辑，实现监听函数调用

并重构 connection 交互逻辑至 worker；TODO `GrpcRemoteClient` 作为通用客户端。
![WX20220924-175946@2x](https://user-images.githubusercontent.com/16837364/192092419-36b3c969-abfa-4d8b-bc6a-47bb9a48f760.png)

