### PR TITLE
Feat: support multi server-addr

### DIFF
--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -43,6 +43,6 @@ pub enum Error {
     #[error("grpcio conn failed: {0}")]
     GrpcioJoin(#[from] grpcio::Error),
 
-    #[error("Wrong grpc address: {0}")]
-    WrongGrpcAddress(String),
+    #[error("Wrong server address: {0}")]
+    WrongServerAddress(String),
 }

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -42,4 +42,7 @@ pub enum Error {
 
     #[error("grpcio conn failed: {0}")]
     GrpcioJoin(#[from] grpcio::Error),
+
+    #[error("Wrong grpc address: {0}")]
+    WrongGrpcAddress(String),
 }

--- a/src/common/remote/grpc/grpc_client.rs
+++ b/src/common/remote/grpc/grpc_client.rs
@@ -27,7 +27,7 @@ pub(crate) struct GrpcClient {
 
 impl GrpcClient {
     pub(crate) async fn new(address: &str) -> Result<Self> {
-        let address = crate::common::remote::into_grpc_server_addr(address);
+        let address = crate::common::remote::into_grpc_server_addr(address)?;
         let address = address.as_str();
         info!("init grpc client: {}", address);
         let env = Arc::new(Environment::new(2));

--- a/src/common/remote/mod.rs
+++ b/src/common/remote/mod.rs
@@ -1,10 +1,14 @@
 pub mod grpc;
 
 use std::sync::atomic::{AtomicI64, Ordering};
+use crate::api::error::Error::WrongGrpcAddress;
+
+use crate::api::error::Result;
 
 // odd by client request id.
 const SEQUENCE_INITIAL_VALUE: i64 = 1;
 const SEQUENCE_DELTA: i64 = 2;
+const IPV4: &str = "ipv4";
 static ATOMIC_SEQUENCE: AtomicI64 = AtomicI64::new(SEQUENCE_INITIAL_VALUE);
 
 pub(crate) fn generate_request_id() -> String {
@@ -16,8 +20,71 @@ pub(crate) fn generate_request_id() -> String {
 }
 
 /// make address's port plus 1000
-pub(crate) fn into_grpc_server_addr(address: &str) -> String {
-    let v: Vec<&str> = address.split(':').collect();
-    let port = v.get(1).unwrap().parse::<u32>().unwrap() + 1000;
-    format!("{}:{}", v.first().unwrap(), port)
+pub(crate) fn into_grpc_server_addr(address: &str) -> Result<String> {
+    match address.split_once(':') {
+        None => Err(WrongGrpcAddress(address.into())),
+        Some((schema, addresses)) if schema.starts_with(IPV4) => {
+            let host_port_pairs = addresses.split(',')
+                .map(|host_port| {
+                    let split = host_port.split(':').collect::<Vec<&str>>();
+                    let host = split.get(0).unwrap();
+                    let port = split.get(1).unwrap().parse::<u32>().unwrap() + 1000;
+                    format!("{host}:{port}")
+                })
+                .collect::<Vec<String>>()
+                .join(",");
+
+            Ok(format!("{}:{}", schema, host_port_pairs))
+        }
+        Some((host, port)) => {
+            let port = port.parse::<u32>().unwrap() + 1000;
+            Ok(format!("{}:{}", host, port))
+        }
+    }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::common::remote::into_grpc_server_addr;
+
+    #[test]
+    fn test_empty_address() {
+        match into_grpc_server_addr("") {
+            Ok(_) => assert!(false),
+            Err(_) => assert!(true)
+        }
+    }
+
+    #[test]
+    fn test_host_address_without_port() {
+        match into_grpc_server_addr("127.0.0.1") {
+            Ok(_) => assert!(false),
+            Err(_) => assert!(true)
+        }
+    }
+
+    #[test]
+    fn test_single_host_address() {
+        let addr = "127.0.0.1:8848";
+        let expected = "127.0.0.1:9848";
+        let result = into_grpc_server_addr(addr).unwrap();
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn test_single_ipv4_address() {
+        let addr = "ipv4:127.0.0.1:8848";
+        let expected = "ipv4:127.0.0.1:9848";
+        let result = into_grpc_server_addr(addr).unwrap();
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn test_multiple_ipv4_address() {
+        let addr = "ipv4:127.0.0.1:8848,127.0.0.1:8849,127.0.0.1:8850";
+        let expected = "ipv4:127.0.0.1:9848,127.0.0.1:9849,127.0.0.1:9850";
+        let result = into_grpc_server_addr(addr).unwrap();
+        assert_eq!(expected, result);
+    }
+}
+

--- a/src/common/remote/mod.rs
+++ b/src/common/remote/mod.rs
@@ -1,6 +1,6 @@
 pub mod grpc;
 
-use crate::api::error::Error::WrongGrpcAddress;
+use crate::api::error::Error::WrongServerAddress;
 use std::sync::atomic::{AtomicI64, Ordering};
 
 use crate::api::error::Result;
@@ -23,7 +23,7 @@ pub(crate) fn generate_request_id() -> String {
 /// make address's port plus 1000
 pub(crate) fn into_grpc_server_addr(address: &str) -> Result<String> {
     match address.split_once(':') {
-        None => Err(WrongGrpcAddress(address.into())),
+        None => Err(WrongServerAddress(address.into())),
         Some((schema, addresses)) if schema.starts_with(IPV4) => {
             let host_port_pairs = addresses
                 .split(',')

--- a/src/common/remote/mod.rs
+++ b/src/common/remote/mod.rs
@@ -1,14 +1,15 @@
 pub mod grpc;
 
-use std::sync::atomic::{AtomicI64, Ordering};
 use crate::api::error::Error::WrongGrpcAddress;
+use std::sync::atomic::{AtomicI64, Ordering};
 
 use crate::api::error::Result;
+
+const IPV4: &str = "ipv4";
 
 // odd by client request id.
 const SEQUENCE_INITIAL_VALUE: i64 = 1;
 const SEQUENCE_DELTA: i64 = 2;
-const IPV4: &str = "ipv4";
 static ATOMIC_SEQUENCE: AtomicI64 = AtomicI64::new(SEQUENCE_INITIAL_VALUE);
 
 pub(crate) fn generate_request_id() -> String {
@@ -24,7 +25,8 @@ pub(crate) fn into_grpc_server_addr(address: &str) -> Result<String> {
     match address.split_once(':') {
         None => Err(WrongGrpcAddress(address.into())),
         Some((schema, addresses)) if schema.starts_with(IPV4) => {
-            let host_port_pairs = addresses.split(',')
+            let host_port_pairs = addresses
+                .split(',')
                 .map(|host_port| {
                     let split = host_port.split(':').collect::<Vec<&str>>();
                     let host = split.get(0).unwrap();
@@ -51,7 +53,7 @@ mod tests {
     fn test_empty_address() {
         match into_grpc_server_addr("") {
             Ok(_) => assert!(false),
-            Err(_) => assert!(true)
+            Err(_) => assert!(true),
         }
     }
 
@@ -59,7 +61,7 @@ mod tests {
     fn test_host_address_without_port() {
         match into_grpc_server_addr("127.0.0.1") {
             Ok(_) => assert!(false),
-            Err(_) => assert!(true)
+            Err(_) => assert!(true),
         }
     }
 
@@ -87,4 +89,3 @@ mod tests {
         assert_eq!(expected, result);
     }
 }
-

--- a/src/common/remote/mod.rs
+++ b/src/common/remote/mod.rs
@@ -3,9 +3,7 @@ pub mod grpc;
 use crate::api::error::Error::WrongServerAddress;
 use std::sync::atomic::{AtomicI64, Ordering};
 
-use crate::api::error::Result;
-
-const IPV4: &str = "ipv4";
+use crate::api::error::{Error, Result};
 
 // odd by client request id.
 const SEQUENCE_INITIAL_VALUE: i64 = 1;
@@ -22,26 +20,37 @@ pub(crate) fn generate_request_id() -> String {
 
 /// make address's port plus 1000
 pub(crate) fn into_grpc_server_addr(address: &str) -> Result<String> {
-    match address.split_once(':') {
-        None => Err(WrongServerAddress(address.into())),
-        Some((schema, addresses)) if schema.starts_with(IPV4) => {
-            let host_port_pairs = addresses
-                .split(',')
-                .map(|host_port| {
-                    let split = host_port.split(':').collect::<Vec<&str>>();
-                    let host = split.get(0).unwrap();
-                    let port = split.get(1).unwrap().parse::<u32>().unwrap() + 1000;
-                    format!("{host}:{port}")
-                })
-                .collect::<Vec<String>>()
-                .join(",");
+    let hosts = address.split(',').collect::<Vec<&str>>();
+    if hosts.len() == 0 {
+        return Err(WrongServerAddress(address.into()));
+    }
 
-            Ok(format!("{}:{}", schema, host_port_pairs))
+    let mut result = vec![];
+    for host in hosts {
+        let host_port_pair = host.split(':').collect::<Vec<&str>>();
+        if host_port_pair.len() != 2 {
+            return Err(WrongServerAddress(address.into()));
         }
-        Some((host, port)) => {
-            let port = port.parse::<u32>().unwrap() + 1000;
-            Ok(format!("{}:{}", host, port))
+
+        let host = host_port_pair.get(0);
+        let port = host_port_pair.get(1);
+        if host.is_none() || port.is_none() {
+            return Err(WrongServerAddress(address.into()));
         }
+
+        let port = port
+            .unwrap()
+            .parse::<u32>()
+            .map(|port| port + 1000)
+            .map_err(|_| WrongServerAddress(address.into()))?;
+
+        result.push(format!("{}:{}", host.unwrap(), port));
+    }
+
+    match result.len() {
+        0 => Err(WrongServerAddress(address.into())),
+        1 => Ok(format!("{}", result.get(0).unwrap())),
+        _ => Ok(format!("ipv4:{}", result.join(","))),
     }
 }
 
@@ -66,6 +75,14 @@ mod tests {
     }
 
     #[test]
+    fn test_host_addresses_without_one_port() {
+        match into_grpc_server_addr("127.0.0.1:8848,127.0.0.1") {
+            Ok(_) => assert!(false),
+            Err(_) => assert!(true),
+        }
+    }
+
+    #[test]
     fn test_single_host_address() {
         let addr = "127.0.0.1:8848";
         let expected = "127.0.0.1:9848";
@@ -74,16 +91,8 @@ mod tests {
     }
 
     #[test]
-    fn test_single_ipv4_address() {
-        let addr = "ipv4:127.0.0.1:8848";
-        let expected = "ipv4:127.0.0.1:9848";
-        let result = into_grpc_server_addr(addr).unwrap();
-        assert_eq!(expected, result);
-    }
-
-    #[test]
     fn test_multiple_ipv4_address() {
-        let addr = "ipv4:127.0.0.1:8848,127.0.0.1:8849,127.0.0.1:8850";
+        let addr = "127.0.0.1:8848,127.0.0.1:8849,127.0.0.1:8850";
         let expected = "ipv4:127.0.0.1:9848,127.0.0.1:9849,127.0.0.1:9850";
         let result = into_grpc_server_addr(addr).unwrap();
         assert_eq!(expected, result);


### PR DESCRIPTION
Crate grpcio supports load balancing so grpc address could be the list of IPs. 
Current code base allows only single ip address. 
That PR addresses that issue. It adds the following format: 
`ipv4:address:port[,address:port],...]`