### PR TITLE
chore: upgrade version to 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # 变更日志 | Change log
 
+### 0.2.3
+
+- 提供 async api，可以通过 `features = ["async"]` 来启用
+- 优化内部逻辑，减少核心线程数目、去除 tls/openssl 依赖
+- 变更 naming api `register_instance/select_instances` 用以替代 `register_service/select_instance`
+- 修复 naming 服务变更的日志打印
+
+---
+
+- Api: provides the async API, which can be enabled via `features = ['async"]`
+- Chore: optimize internal logic, reduce the number of core threads, remove tls/openssl dependencies
+- Change: naming api `register_instance/select_instances` instead of `register_service/select_instance`
+- Fix: naming changed service log
+
 ### 0.2.2
 
 - 修复 cluster_name 无效

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@
 
 [package]
 name = "nacos-sdk"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 authors = ["nacos-group", "CheirshCai <785427346@qq.com>", "onewe <2583021406@qq.com>"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Add the dependency in `Cargo.toml`:
 
 ```toml
 [dependencies]
+# If you need async API, which can be enabled via `features = ['async"]`
 nacos-sdk = { version = "0.2", features = ["default"] }
 ```
 

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -1,9 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-#[cfg(feature = "async")]
-use async_trait::async_trait;
-
 use crate::api::{error, plugin, props};
 
 /// Api [`ConfigService`].
@@ -89,7 +86,7 @@ pub trait ConfigService {
 }
 
 #[cfg(feature = "async")]
-#[async_trait]
+#[async_trait::async_trait]
 pub trait ConfigService {
     /// Get config, return the content.
     ///

--- a/src/api/naming.rs
+++ b/src/api/naming.rs
@@ -5,9 +5,6 @@ use crate::api::plugin;
 use crate::{api::error::Result, naming::NacosNamingService};
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "async")]
-use async_trait::async_trait;
-
 use super::props::ClientProps;
 
 const DEFAULT_CLUSTER_NAME: &str = "DEFAULT";
@@ -237,7 +234,7 @@ pub trait NamingService {
 }
 
 #[cfg(feature = "async")]
-#[async_trait]
+#[async_trait::async_trait]
 pub trait NamingService {
     async fn register_instance(
         &self,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,9 +9,6 @@ use crate::api::plugin::{AuthPlugin, ConfigFilter};
 use crate::api::props::ClientProps;
 use crate::config::worker::ConfigWorker;
 
-#[cfg(feature = "async")]
-use async_trait::async_trait;
-
 pub(crate) struct NacosConfigService {
     /// config client worker
     client_worker: ConfigWorker,
@@ -129,7 +126,7 @@ impl ConfigService for NacosConfigService {
 }
 
 #[cfg(feature = "async")]
-#[async_trait]
+#[async_trait::async_trait]
 impl ConfigService for NacosConfigService {
     async fn get_config(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! ## Add Dependency
 //!
 //! Add the dependency in `Cargo.toml`:
-//!
+//! - If you need async API, which can be enabled via `features = ['async"]`
 //! ```toml
 //! [dependencies]
 //! nacos-sdk = { version = "0.2", features = ["default"] }

--- a/src/naming/mod.rs
+++ b/src/naming/mod.rs
@@ -39,9 +39,6 @@ use self::subscribers::InstancesChangeEventSubscriber;
 use self::subscribers::RedoTaskDisconnectEventSubscriber;
 use self::subscribers::RedoTaskReconnectEventSubscriber;
 
-#[cfg(feature = "async")]
-use async_trait::async_trait;
-
 mod chooser;
 mod dto;
 mod events;
@@ -649,7 +646,7 @@ impl NamingService for NacosNamingService {
 }
 
 #[cfg(feature = "async")]
-#[async_trait]
+#[async_trait::async_trait]
 impl NamingService for NacosNamingService {
     async fn deregister_instance(
         &self,


### PR DESCRIPTION
### 0.2.3

- 提供 async api，可以通过 `features = ["async"]` 来启用
- 优化内部逻辑，减少核心线程数目、去除 tls/openssl 依赖
- 变更 naming api `register_instance/select_instances` 用以替代 `register_service/select_instance`
- 修复 naming 服务变更的日志打印

---

- Api: provides the async API, which can be enabled via `features = ['async"]`
- Chore: optimize internal logic, reduce the number of core threads, remove tls/openssl dependencies
- Change: naming api `register_instance/select_instances` instead of `register_service/select_instance`
- Fix: naming changed service log