### PR TITLE
chore: upgrade version to 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # 变更日志 | Change log
 
+### 0.2.4
+
+- 清理无用代码
+- login url 携带账号密码
+- 统一使用变量名占位方式打印日志
+- 支持 https login 认证
+- 支持自定义 grpc 端口
+- 实现 List-Watch 机制 naming 模块
+- 设置默认 grpc 请求超时时间
+- 修复服务端多次推送服务变更信息
+
+---
+
+- Chore: login with url encode username password.
+- Chore: clean code with clippy 
+- Chore: log macro args into string 
+- Feature: add https scheme in feathre for auth and custom grpc port support 
+- Feature: implement List-Watch for naming module 
+- Enhance: set default timeout 
+- Fix: service info push many times from server 
+
 ### 0.2.3
 
 - 提供 async api，可以通过 `features = ["async"]` 来启用

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@
 
 [package]
 name = "nacos-sdk"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["nacos-group", "CheirshCai <785427346@qq.com>", "onewe <2583021406@qq.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### 0.2.4

- 清理无用代码
- auth_login url_encode 账号,密码
- 统一使用变量名占位方式打印日志
- 支持 https login 认证
- 支持自定义 grpc 端口
- 实现 List-Watch 机制 naming 模块
- 设置默认 grpc 请求超时时间
- 修复服务端多次推送服务变更信息

---

- Chore: login with url encode username password.
- Chore: clean code with clippy 
- Chore: log macro args into string 
- Feature: add https scheme in feathre for auth and custom grpc port support 
- Feature: implement List-Watch for naming module 
- Enhance: set default timeout 
- Fix: service info push many times from server 