### PR TITLE
opt: env `NACOS_CLIENT_COMMON_THREAD_CORES` to set worker_threads

### DIFF
--- a/src/api/constants.rs
+++ b/src/api/constants.rs
@@ -26,3 +26,6 @@ pub(crate) mod common_remote {
     /// LABEL_MODULE value config
     pub const LABEL_MODULE_CONFIG: &str = "config";
 }
+
+/// env `NACOS_CLIENT_COMMON_THREAD_CORES` to set num when multi-cpus, default is num_cpus
+pub(crate) const ENV_NACOS_CLIENT_COMMON_THREAD_CORES: &str = "NACOS_CLIENT_COMMON_THREAD_CORES";

--- a/src/common/executor/mod.rs
+++ b/src/common/executor/mod.rs
@@ -9,9 +9,15 @@ use tokio::{
 use tracing::{error, Instrument};
 
 lazy_static! {
+    static ref COMMON_THREAD_CORES: usize = std::env::var(crate::api::constants::ENV_NACOS_CLIENT_COMMON_THREAD_CORES)
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok().filter(|n| *n > 0))
+        .unwrap_or(std::thread::available_parallelism().unwrap().get()); // default is num_cpus
+
     static ref RT: Runtime = Builder::new_multi_thread()
         .enable_all()
         .thread_name("nacos-client-thread-pool")
+        .worker_threads(*COMMON_THREAD_CORES)
         .build()
         .unwrap();
 }

--- a/src/common/executor/mod.rs
+++ b/src/common/executor/mod.rs
@@ -87,17 +87,18 @@ pub(crate) fn schedule_at_fixed_delay(
 mod tests {
 
     use super::*;
+    use crate::api::constants::ENV_NACOS_CLIENT_COMMON_THREAD_CORES;
 
     #[test]
     fn test_common_thread_cores() {
-        let num_cpus = std::env::var(crate::api::constants::ENV_NACOS_CLIENT_COMMON_THREAD_CORES)
+        let num_cpus = std::env::var(ENV_NACOS_CLIENT_COMMON_THREAD_CORES)
             .ok()
             .and_then(|v| v.parse::<usize>().ok().filter(|n| *n > 0))
             .unwrap_or(std::thread::available_parallelism().unwrap().get());
         assert!(num_cpus > 0);
 
-        std::env::set_var(crate::api::constants::ENV_NACOS_CLIENT_COMMON_THREAD_CORES, "4");
-        let num_cpus = std::env::var(crate::api::constants::ENV_NACOS_CLIENT_COMMON_THREAD_CORES)
+        std::env::set_var(ENV_NACOS_CLIENT_COMMON_THREAD_CORES, "4");
+        let num_cpus = std::env::var(ENV_NACOS_CLIENT_COMMON_THREAD_CORES)
             .ok()
             .and_then(|v| v.parse::<usize>().ok().filter(|n| *n > 0))
             .unwrap_or(std::thread::available_parallelism().unwrap().get());

--- a/src/common/executor/mod.rs
+++ b/src/common/executor/mod.rs
@@ -89,6 +89,22 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_common_thread_cores() {
+        let num_cpus = std::env::var(crate::api::constants::ENV_NACOS_CLIENT_COMMON_THREAD_CORES)
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok().filter(|n| *n > 0))
+            .unwrap_or(std::thread::available_parallelism().unwrap().get());
+        assert!(num_cpus > 0);
+
+        std::env::set_var(crate::api::constants::ENV_NACOS_CLIENT_COMMON_THREAD_CORES, "4");
+        let num_cpus = std::env::var(crate::api::constants::ENV_NACOS_CLIENT_COMMON_THREAD_CORES)
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok().filter(|n| *n > 0))
+            .unwrap_or(std::thread::available_parallelism().unwrap().get());
+        assert_eq!(num_cpus, 4);
+    }
+
+    #[test]
     fn test_spawn() {
         let handler = spawn(async {
             println!("test spawn task");

--- a/src/config/worker.rs
+++ b/src/config/worker.rs
@@ -68,7 +68,6 @@ impl ConfigWorker {
             .build()?;
 
         // todo Event/Subscriber instead of mpsc Sender/Receiver
-
         crate::common::executor::spawn(
             Self::notify_change_to_cache_data(
                 Arc::clone(&remote_client),


### PR DESCRIPTION
- env `NACOS_CLIENT_COMMON_THREAD_CORES` to set worker_threads when multi-cpus, default is num_cpus