### PR TITLE
合并main分支的"HttpLoginAuthPlugin和ServiceInfoUpdateTask的BUG修复"至0.3.x分支

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Cargo.lock
 # IDE
 .idea
 .vscode
+.history
 
 # Customize
 ### google.protobuf.rs build by prost-build, exclude it because no content.

--- a/src/api/plugin/auth/auth_by_http.rs
+++ b/src/api/plugin/auth/auth_by_http.rs
@@ -45,8 +45,8 @@ impl AuthPlugin for HttpLoginAuthPlugin {
             return;
         }
 
-        let username = auth_context.params.get(USERNAME).unwrap();
-        let password = auth_context.params.get(PASSWORD).unwrap();
+        let username = auth_context.params.get(USERNAME).unwrap().to_owned();
+        let password = auth_context.params.get(PASSWORD).unwrap().to_owned();
 
         let server_addr = {
             let mutex = self.server_list.read().unwrap();
@@ -66,7 +66,7 @@ impl AuthPlugin for HttpLoginAuthPlugin {
 
         tracing::debug!("Http login with username={username},password={password}");
 
-        let future = async {
+        let future = async move {
             let resp = reqwest::Client::new()
                 .post(login_url)
                 .query(&[(USERNAME, username), (PASSWORD, password)])
@@ -87,9 +87,14 @@ impl AuthPlugin for HttpLoginAuthPlugin {
             Some(resp_obj.unwrap())
         };
 
-        let login_response = futures::executor::block_on(future);
+        let login_response = futures::executor::block_on(crate::common::executor::spawn(future));
 
-        if let Some(login_response) = login_response {
+        if let Err(e) = login_response.as_ref() {
+            tracing::error!("Spawn Http login task failed. {e:?}");
+            return;
+        }
+
+        if let Ok(Some(login_response)) = login_response {
             let delay_sec = login_response.token_ttl / 10;
             let new_login_identity = LoginIdentityContext::default()
                 .add_context(ACCESS_TOKEN, login_response.access_token);
@@ -131,7 +136,7 @@ mod tests {
             .init();
 
         let http_auth_plugin = HttpLoginAuthPlugin::default();
-        http_auth_plugin.set_server_list(vec!["0.0.0.0:8848".to_string()]);
+        http_auth_plugin.set_server_list(vec!["127.0.0.1:8848".to_string()]);
 
         let auth_context = AuthContext::default()
             .add_param(crate::api::plugin::USERNAME, "nacos")

--- a/src/common/remote/grpc/nacos_grpc_client.rs
+++ b/src/common/remote/grpc/nacos_grpc_client.rs
@@ -391,6 +391,7 @@ pub mod tests {
 
     use super::*;
 
+    #[ignore]
     #[tokio::test]
     pub async fn test() {
         tracing_subscriber::fmt()

--- a/src/common/remote/grpc/nacos_grpc_service.rs
+++ b/src/common/remote/grpc/nacos_grpc_service.rs
@@ -333,6 +333,7 @@ pub mod unary_call_layer_test {
         }
     }
 
+    #[ignore]
     #[tokio::test]
     pub async fn test() {
         tracing_subscriber::fmt()

--- a/src/common/remote/grpc/server_list_service.rs
+++ b/src/common/remote/grpc/server_list_service.rs
@@ -99,6 +99,7 @@ pub mod tests {
         let _ = PollingServerListService::new(vec!["127.0.0.1:sd".to_string()]);
     }
 
+    #[ignore]
     #[tokio::test]
     pub async fn test_poll_server_list() {
         tracing_subscriber::fmt()

--- a/src/naming/updater/mod.rs
+++ b/src/naming/updater/mod.rs
@@ -10,11 +10,17 @@ use std::{
 use tokio::{sync::Mutex, time::sleep};
 use tracing::{debug, error, info, instrument, warn, Instrument};
 
-use crate::common::{
-    executor,
-    remote::{
-        generate_request_id,
-        grpc::{message::GrpcResponseMessage, NacosGrpcClient},
+use crate::{
+    api::plugin::AuthPlugin,
+    common::{
+        executor,
+        remote::{
+            generate_request_id,
+            grpc::{
+                message::{GrpcRequestMessage, GrpcResponseMessage},
+                NacosGrpcClient,
+            },
+        },
     },
 };
 
@@ -30,6 +36,7 @@ pub(crate) struct ServiceInfoUpdater {
     namespace: String,
     task_map: Mutex<HashMap<String, ServiceInfoUpdateTask>>,
     client_id: String,
+    auth_plugin: Arc<dyn AuthPlugin>,
 }
 
 impl ServiceInfoUpdater {
@@ -38,6 +45,7 @@ impl ServiceInfoUpdater {
         nacos_grpc_client: Arc<NacosGrpcClient>,
         namespace: String,
         client_id: String,
+        auth_plugin: Arc<dyn AuthPlugin>,
     ) -> Self {
         Self {
             service_info_holder,
@@ -45,6 +53,7 @@ impl ServiceInfoUpdater {
             namespace,
             task_map: Mutex::new(HashMap::default()),
             client_id,
+            auth_plugin,
         }
     }
 
@@ -67,6 +76,7 @@ impl ServiceInfoUpdater {
                 cluster,
                 self.service_info_holder.clone(),
                 self.nacos_grpc_client.clone(),
+                self.auth_plugin.clone(),
             );
             update_task.start();
 
@@ -103,6 +113,7 @@ struct ServiceInfoUpdateTask {
     cluster: String,
     service_info_holder: Arc<ServiceInfoHolder>,
     nacos_grpc_client: Arc<NacosGrpcClient>,
+    auth_plugin: Arc<dyn AuthPlugin>,
 }
 
 impl ServiceInfoUpdateTask {
@@ -117,6 +128,7 @@ impl ServiceInfoUpdateTask {
         cluster: String,
         service_info_holder: Arc<ServiceInfoHolder>,
         nacos_grpc_client: Arc<NacosGrpcClient>,
+        auth_plugin: Arc<dyn AuthPlugin>,
     ) -> Self {
         Self {
             running: Arc::new(AtomicBool::new(false)),
@@ -126,6 +138,7 @@ impl ServiceInfoUpdateTask {
             cluster,
             service_info_holder,
             nacos_grpc_client,
+            auth_plugin,
         }
     }
 
@@ -143,6 +156,7 @@ impl ServiceInfoUpdateTask {
 
         let service_info_holder = self.service_info_holder.clone();
         let grpc_client = self.nacos_grpc_client.clone();
+        let auth_plugin = self.auth_plugin.clone();
 
         executor::spawn(async move {
             let mut delay_time = ServiceInfoUpdateTask::DEFAULT_DELAY;
@@ -211,6 +225,7 @@ impl ServiceInfoUpdateTask {
 
                 let mut request = request.clone();
                 request.request_id = Some(generate_request_id());
+                request.add_headers(auth_plugin.get_login_identity().contexts);
 
                 let ret = grpc_client
                     .send_request::<ServiceQueryRequest, QueryServiceResponse>(request)


### PR DESCRIPTION
1. HttpLoginAuthPlugin在 tokio::test 下的死锁问题
2. ServiceInfoUpdateTask中发送的请求丢失token的问题