### PR TITLE
chore: upgrade version to 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # 变更日志 | Change log
 
+### 0.2.6
+
+- 修复 `ServiceInfoUpdateTask` 丢失 auth header
+
+---
+
+- fix lose auth headers in ServiceInfoUpdateTask
+
 ### 0.2.5
 
 - 优化重连机制

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@
 
 [package]
 name = "nacos-sdk"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 authors = ["nacos-group", "CheirshCai <785427346@qq.com>", "onewe <2583021406@qq.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### 0.2.6

- 修复 `ServiceInfoUpdateTask` 丢失 auth header

---

- fix lose auth headers in ServiceInfoUpdateTask