### PR TITLE
修复示例中的 “Connection is unregistered” 错误日志

### DIFF
--- a/src/common/remote/grpc/nacos_grpc_connection.rs
+++ b/src/common/remote/grpc/nacos_grpc_connection.rs
@@ -171,6 +171,11 @@ where
         .in_current_span()
         .await?;
 
+        // check server
+        let connection_id = NacosGrpcConnection::<M>::check_server(&mut service)
+            .in_current_span()
+            .await?;
+
         // connection health check
         for i in 0..4 {
             let health_check = NacosGrpcConnection::<M>::connection_health_check(&mut service)
@@ -182,11 +187,6 @@ where
             }
             break;
         }
-
-        // check server
-        let connection_id = NacosGrpcConnection::<M>::check_server(&mut service)
-            .in_current_span()
-            .await?;
 
         let conn_id_send_ret = conn_id_sender.send(connection_id.clone());
         if let Err(e) = conn_id_send_ret {


### PR DESCRIPTION
运行示例会得到一条日志：
`2023-12-22T02:38:21.520575Z  WARN nacos-client-thread-pool ThreadId(22) grpc_connection{id="naming:127.0.0.1:8848:public:1"}: nacos_sdk::common::remote::grpc::message: payload type ErrorResponse, target type HealthCheckResponse, trying convert to ErrorResponse
2023-12-22T02:38:21.520620Z ERROR nacos-client-thread-pool ThreadId(22) grpc_connection{id="naming:127.0.0.1:8848:public:1"}: nacos_sdk::common::remote::grpc::nacos_grpc_connection: connection health check failed convert to grpc message failed. request_id:None ret_code:500 error_code:301 message:Some("Connection is unregistered.")`
虽然不影响后续使用，但这样的错误日志会给人误导，特别是像我这样刚接触 nacos 的人