### PR TITLE
chore: doc hold Client for the app lifetime, log WARN 'connection health check failed'

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ nacos-sdk = { version = "0.3", features = ["default"] }
 
 ### Usage of Config
 ```rust
+    // 请注意！一般情况下，应用下仅需一个 Config 客户端，而且需要长期持有直至应用停止。
+    // 因为它内部会初始化与服务端的长链接，后续的数据交互及变更订阅，都是实时地通过长链接告知客户端的。
     let config_service = ConfigServiceBuilder::new(
         ClientProps::new()
             .server_addr("0.0.0.0:8848")
@@ -69,6 +71,8 @@ nacos-sdk = { version = "0.3", features = ["default"] }
 
 ### Usage of Naming
 ```rust
+    // 请注意！一般情况下，应用下仅需一个 Naming 客户端，而且需要长期持有直至应用停止。
+    // 因为它内部会初始化与服务端的长链接，后续的数据交互及变更订阅，都是实时地通过长链接告知客户端的。
     let naming_service = NamingServiceBuilder::new(
         ClientProps::new()
             .server_addr("0.0.0.0:8848")

--- a/examples/simple_app.rs
+++ b/examples/simple_app.rs
@@ -33,6 +33,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ;
 
     // ----------  Config  -------------
+    // 请注意！一般情况下，应用下仅需一个 Config 客户端，而且需要长期持有直至应用停止。
+    // 因为它内部会初始化与服务端的长链接，后续的数据交互及变更订阅，都是实时地通过长链接告知客户端的。
     let config_service = ConfigServiceBuilder::new(client_props.clone())
         .enable_auth_plugin_http() // TODO You can choose not to enable auth
         .build()?;
@@ -53,6 +55,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // ----------  Naming  -------------
+    // 请注意！一般情况下，应用下仅需一个 Naming 客户端，而且需要长期持有直至应用停止。
+    // 因为它内部会初始化与服务端的长链接，后续的数据交互及变更订阅，都是实时地通过长链接告知客户端的。
     let naming_service = NamingServiceBuilder::new(client_props)
         .enable_auth_plugin_http() // TODO You can choose not to enable auth
         .build()?;

--- a/src/common/remote/grpc/nacos_grpc_connection.rs
+++ b/src/common/remote/grpc/nacos_grpc_connection.rs
@@ -374,8 +374,8 @@ where
 
         let response = GrpcMessage::<HealthCheckResponse>::from_payload(response);
         if let Err(e) = response {
-            error!(
-                "connection health check failed convert to grpc message failed. {}",
+            warn!(
+                "connection health check failed convert to grpc message failed. If the retry is successful, please ignore it. {}",
                 e
             );
             return Err(ErrResult(


### PR DESCRIPTION
chore: 
- doc hold Client for the app lifetime,
- log WARN 'connection health check failed'