### PR TITLE
Fix panic on string truncation by using safe UTF-8 character boundary handling

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -163,8 +163,8 @@ pub struct ConfigResponse {
 impl std::fmt::Display for ConfigResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut content = self.content.clone();
-        if content.len() > 30 {
-            content.truncate(30);
+        if content.chars().count() > 30 {
+            content = content.chars().take(30).collect();
             content.push_str("...");
         }
         write!(

--- a/src/config/cache.rs
+++ b/src/config/cache.rs
@@ -133,8 +133,8 @@ impl CacheData {
 impl std::fmt::Display for CacheData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut content = self.content.clone();
-        if content.len() > 30 {
-            content.truncate(30);
+        if content.chars().count() > 30 {
+            content = content.chars().take(30).collect();
             content.push_str("...");
         }
         write!(


### PR DESCRIPTION
Replaced String::truncate with .chars().take(n).collect() to avoid panic caused by slicing multibyte characters like Chinese.