### PR TITLE
bump: upgrade 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # 变更日志 | Change log
 
+### 0.8.0
+
+- 破坏性变更：自定义 `AuthPlugin` 需要适配 `login` 方法签名（参数改为 `Arc` 包装）；`remote_grpc_port` 参数类型 `u32` → `u16`
+- 特性：新增 `endpoint` 配置，支持从远程服务端点动态获取服务器列表，`endpoint` 优先级高于 `server_addr`
+- 增强：CI 添加 sccache 编译缓存、`thiserror` 升级至 2.0、`url` crate 统一处理 endpoint URL
+
+---
+
+- Change: custom `AuthPlugin` needs to adapt `login` method signature (params wrapped in `Arc`); `remote_grpc_port` parameter type `u32` → `u16`
+- Feature: add `endpoint` for dynamic server list resolution, `endpoint` takes priority over `server_addr`
+- Chore: add sccache compilation caching for CI, upgrade `thiserror` to 2.0, unify `url` crate for endpoint URL
+
 ### 0.7.0
 
 - 特性：提供 gRPC TLS 支持，通过 `features = ["tls"]` 开启，支持自定义 CA 证书

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@
 
 [package]
 name = "nacos-sdk"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 authors = ["nacos-group", "CheirshCai <785427346@qq.com>", "onewe <2583021406@qq.com>"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the dependency in `Cargo.toml`:
 
 ```toml
 [dependencies]
-nacos-sdk = { version = "0.7", features = ["default"] }
+nacos-sdk = { version = "0.8", features = ["default"] }
 ```
 
 ### Usage of Config
@@ -117,7 +117,7 @@ nacos-sdk = { version = "0.7", features = ["default"] }
 ```
 
 ### Props
-Props count be set by `ClientProps`, or Environment variables (Higher priority).
+Props could be set by `ClientProps`, or Environment variables (Higher priority).
 See them in `nacos_sdk::api::props::ClientProps` or `nacos_sdk::api::constants::ENV_NACOS_CLIENT_*`.
 e.g.
 - env `NACOS_CLIENT_COMMON_THREAD_CORES` to set nacos-client-thread-pool num, default 1
@@ -176,7 +176,7 @@ let naming_service = NamingServiceBuilder::new(props).build().await?;
     - enable auth-by-http(default is enabled)
     ```toml
     [dependencies]
-    nacos-sdk = { version = "0.7", features = ["default"] }
+    nacos-sdk = { version = "0.8", features = ["default"] }
     ```
     - Set username and password via environment variables
     ```shell
@@ -202,7 +202,7 @@ let naming_service = NamingServiceBuilder::new(props).build().await?;
     - enable auth-by-aliyun feature in toml
     ```toml
     [dependencies]
-    nacos-sdk = { version = "0.7", features = ["default", "auth-by-aliyun"] }
+    nacos-sdk = { version = "0.8", features = ["default", "auth-by-aliyun"] }
     ```
     - Set accessKey and secretKey via environment variables
     ```shell

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //! Add the dependency in `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! nacos-sdk = { version = "0.7", features = ["default"] }
+//! nacos-sdk = { version = "0.8", features = ["default"] }
 //! ```
 //!
 //! ## General Configurations and Initialization


### PR DESCRIPTION
## Summary
- Upgrade version to 0.8.0
- Update CHANGELOG.md with 0.8.0 changes

## Breaking Changes
- Custom `AuthPlugin` needs to adapt `login` method signature (params wrapped in `Arc`)
- `remote_grpc_port` parameter type `u32` → `u16`

## Features
- Add `endpoint` for dynamic server list resolution

## Enhancements
- CI: add sccache compilation caching
- Upgrade `thiserror` to 2.0
- Unify `url` crate for endpoint URL