### PR TITLE
chore: server list logging & clippy fixes

### DIFF
--- a/examples/aliyun_ram_app.rs
+++ b/examples/aliyun_ram_app.rs
@@ -40,9 +40,11 @@ async fn run_naming_demo() {
         .await
         .expect("Failed to build naming service with Aliyun RAM auth");
 
-    let mut instance = ServiceInstance::default();
-    instance.ip = "localhost".to_string();
-    instance.port = 8080;
+    let instance = ServiceInstance {
+        ip: "localhost".to_string(),
+        port: 8080,
+        ..Default::default()
+    };
 
     println!("Register localhost:8080 to service(name: test, group: test)");
     naming_client

--- a/src/api/plugin/auth/auth_by_aliyun_ram.rs
+++ b/src/api/plugin/auth/auth_by_aliyun_ram.rs
@@ -404,19 +404,25 @@ mod test {
 
     #[test]
     fn test_get_resource_for_config() {
-        let mut resource = RequestResource::default();
-        resource.group = Some("test-group".to_owned());
+        let resource = RequestResource {
+            group: Some("test-group".to_owned()),
+            ..Default::default()
+        };
         let resource = AliyunRamAuthPlugin::get_resource_for_config(&resource);
         assert_eq!("test-group", resource);
 
-        let mut resource = RequestResource::default();
-        resource.namespace = Some("test-ns".to_owned());
+        let resource = RequestResource {
+            namespace: Some("test-ns".to_owned()),
+            ..Default::default()
+        };
         let resource = AliyunRamAuthPlugin::get_resource_for_config(&resource);
         assert_eq!("test-ns", resource);
 
-        let mut resource = RequestResource::default();
-        resource.namespace = Some("test-ns".to_owned());
-        resource.group = Some("test-group".to_owned());
+        let resource = RequestResource {
+            namespace: Some("test-ns".to_owned()),
+            group: Some("test-group".to_owned()),
+            ..Default::default()
+        };
         let resource = AliyunRamAuthPlugin::get_resource_for_config(&resource);
         assert_eq!("test-ns+test-group", resource);
 
@@ -427,25 +433,31 @@ mod test {
 
     #[test]
     fn test_get_grouped_service() {
-        let mut resource = RequestResource::default();
-        resource.resource = Some("test@@test".to_owned());
+        let resource = RequestResource {
+            resource: Some("test@@test".to_owned()),
+            ..Default::default()
+        };
         let grouped_service_name = AliyunRamAuthPlugin::get_grouped_service_name(&resource);
         assert_eq!(
             "test@@test",
             grouped_service_name.expect("Grouped service name should exist")
         );
 
-        let mut resource = RequestResource::default();
-        resource.resource = Some("test".to_owned());
+        let resource = RequestResource {
+            resource: Some("test".to_owned()),
+            ..Default::default()
+        };
         let grouped_service_name = AliyunRamAuthPlugin::get_grouped_service_name(&resource);
         assert_eq!(
             "test",
             grouped_service_name.expect("Grouped service name should exist")
         );
 
-        let mut resource = RequestResource::default();
-        resource.resource = Some("test".to_owned());
-        resource.group = Some("test".to_owned());
+        let resource = RequestResource {
+            resource: Some("test".to_owned()),
+            group: Some("test".to_owned()),
+            ..Default::default()
+        };
         let grouped_service_name = AliyunRamAuthPlugin::get_grouped_service_name(&resource);
         assert_eq!(
             "test@@test",
@@ -455,8 +467,10 @@ mod test {
 
     #[test]
     fn test_get_sign_data() {
-        let mut request = RequestResource::default();
-        request.resource = Some("test".to_owned());
+        let request = RequestResource {
+            resource: Some("test".to_owned()),
+            ..Default::default()
+        };
         let sign_data = AliyunRamAuthPlugin::get_sign_data(&request)
             .expect("Sign data should exist for request");
         assert!(sign_data.contains("@@test"))
@@ -473,11 +487,12 @@ mod test {
             .login(Arc::new(Vec::new()), Arc::new(context))
             .await;
 
-        let mut resource = RequestResource::default();
-        resource.request_type = "Naming".to_owned();
-        resource.namespace = Some("".to_owned());
-        resource.group = Some("test-group".to_owned());
-        resource.resource = Some("test-resource".to_owned());
+        let resource = RequestResource {
+            request_type: "Naming".to_owned(),
+            namespace: Some("".to_owned()),
+            group: Some("test-group".to_owned()),
+            resource: Some("test-resource".to_owned()),
+        };
         let identity_context = aliyun_ram_auth_plugin.get_login_identify_for_naming(resource);
         assert_eq!(4, identity_context.contexts.len());
         assert_eq!(
@@ -510,7 +525,7 @@ mod test {
                 "cn-hangzhou",
             );
         assert_eq!(
-            sign_utils::sign_with_hmac_sha1(&data, &signature_key),
+            sign_utils::sign_with_hmac_sha1(data, &signature_key),
             sign_data
         );
     }
@@ -526,11 +541,12 @@ mod test {
             .login(Arc::new(Vec::new()), Arc::new(context))
             .await;
 
-        let mut resource = RequestResource::default();
-        resource.request_type = "Config".to_owned();
-        resource.namespace = Some("".to_owned());
-        resource.group = Some("test-group".to_owned());
-        resource.resource = Some("test-resource".to_owned());
+        let resource = RequestResource {
+            request_type: "Config".to_owned(),
+            namespace: Some("".to_owned()),
+            group: Some("test-group".to_owned()),
+            resource: Some("test-resource".to_owned()),
+        };
         let identity_context = aliyun_ram_auth_plugin.get_login_identify_for_config(resource);
         assert_eq!(4, identity_context.contexts.len());
         assert_eq!(
@@ -605,10 +621,11 @@ mod test {
     }
 
     fn make_service_instance(ip: &str, port: i32) -> ServiceInstance {
-        let mut instance = ServiceInstance::default();
-        instance.ip = ip.to_string();
-        instance.port = port;
-        instance
+        ServiceInstance {
+            ip: ip.to_string(),
+            port,
+            ..Default::default()
+        }
     }
 
     #[ignore]

--- a/src/common/remote/server_list/mod.rs
+++ b/src/common/remote/server_list/mod.rs
@@ -35,6 +35,7 @@ pub(crate) fn parse_server_list(server_addr: &str) -> Result<Vec<String>> {
         .collect();
 
     if result.is_empty() {
+        tracing::warn!("Server address is empty after parsing: {:?}", server_addr);
         return Err(Error::WrongServerAddress("Server address is empty".into()));
     }
 
@@ -59,6 +60,10 @@ pub(crate) fn parse_host_port_vec(server_list: &[String]) -> Result<Vec<(&str, u
         })
         .collect();
     if result_list.is_empty() {
+        tracing::warn!(
+            "All server addresses have illegal format: {:?}",
+            server_list
+        );
         return Err(Error::WrongServerAddress(
             "all the server is illegal format!".into(),
         ));

--- a/src/common/remote/server_list/provider.rs
+++ b/src/common/remote/server_list/provider.rs
@@ -66,11 +66,25 @@ impl EndpointServerListProvider {
 impl ServerListProvider for EndpointServerListProvider {
     async fn current_server_list(&self) -> Arc<Vec<String>> {
         if !self.should_refresh() {
+            tracing::debug!(
+                "Server list not yet due for refresh from endpoint {}, returning cached",
+                self.endpoint_url
+            );
             return Arc::clone(&self.cached_server_list.load());
         }
 
         match fetch_server_list(&self.endpoint_url).await {
             Ok(server_list) => {
+                let cached = self.cached_server_list.load();
+                let changed = !crate::common::util::unordered_eq(&cached, &server_list);
+                if changed {
+                    tracing::info!(
+                        "Server list refreshed from endpoint {}: {:?} -> {:?}",
+                        self.endpoint_url,
+                        *cached,
+                        server_list
+                    );
+                }
                 self.cached_server_list.store(Arc::new(server_list));
             }
             Err(e) => {
@@ -95,16 +109,26 @@ pub(crate) async fn create_server_list_provider(
         let namespace = client_props.get_namespace_default_if_empty();
         let endpoint_url = build_endpoint_url(&endpoint, &namespace);
         let initial_list = fetch_server_list(&endpoint_url).await?;
+        tracing::info!(
+            "Create EndpointServerListProvider with server_list={:?}, endpoint_url={}",
+            initial_list,
+            endpoint_url
+        );
         let provider = EndpointServerListProvider::new(endpoint_url, initial_list);
         Ok(Arc::new(provider))
     } else {
         let server_addr = client_props.get_server_addr();
         let server_list = super::parse_server_list(&server_addr)?;
+        tracing::info!(
+            "Create StaticServerListProvider with server_list={:?}",
+            server_list
+        );
         Ok(Arc::new(StaticServerListProvider::new(server_list)))
     }
 }
 
 async fn fetch_server_list(endpoint_url: &str) -> crate::api::error::Result<Vec<String>> {
+    tracing::debug!("Fetching server list from {}", endpoint_url);
     let http_client = crate::common::remote::http_client();
     let response = http_client.get(endpoint_url).send().await.map_err(|err| {
         Error::WrongServerAddress(format!(

--- a/src/common/remote/server_list/service.rs
+++ b/src/common/remote/server_list/service.rs
@@ -61,6 +61,7 @@ impl Service<()> for PollingServerListService {
                 host: host.to_string(),
                 port: *port,
             };
+            tracing::debug!("Polling server selected: {}:{} (index {})", host, port, idx);
             Ok(Arc::new(server_address) as Arc<dyn ServerAddress>)
         })
     }

--- a/src/common/util.rs
+++ b/src/common/util.rs
@@ -35,6 +35,22 @@ pub(crate) fn normalize_group_name(group_name: Option<String>) -> String {
         .unwrap_or_else(|| crate::api::constants::DEFAULT_GROUP.to_owned())
 }
 
+/// Checks whether two slices contain the same elements regardless of order.
+/// Duplicates are significant: `[a, a]` != `[a]`.
+pub(crate) fn unordered_eq<T>(a: &[T], b: &[T]) -> bool
+where
+    T: Ord,
+{
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut a_sorted: Vec<&T> = a.iter().collect();
+    let mut b_sorted: Vec<&T> = b.iter().collect();
+    a_sorted.sort();
+    b_sorted.sort();
+    a_sorted == b_sorted
+}
+
 /// Checks param_val not blank
 pub(crate) fn check_not_blank<'a>(param_val: &'a str, param_name: &'a str) -> Result<&'a str> {
     if param_val.trim().is_empty() {
@@ -49,7 +65,32 @@ pub(crate) fn check_not_blank<'a>(param_val: &'a str, param_name: &'a str) -> Re
 
 #[cfg(test)]
 mod tests {
-    use crate::common::util::check_not_blank;
+    use crate::common::util::{check_not_blank, unordered_eq};
+
+    #[test]
+    fn test_unordered_eq_same_order() {
+        assert!(unordered_eq(&["a", "b"], &["a", "b"]));
+    }
+
+    #[test]
+    fn test_unordered_eq_different_order() {
+        assert!(unordered_eq(&["b", "a"], &["a", "b"]));
+    }
+
+    #[test]
+    fn test_unordered_eq_different_length() {
+        assert!(!unordered_eq(&["a"], &["a", "b"]));
+    }
+
+    #[test]
+    fn test_unordered_eq_duplicates_significant() {
+        assert!(!unordered_eq(&["a", "a"], &["a"]));
+    }
+
+    #[test]
+    fn test_unordered_eq_empty() {
+        assert!(unordered_eq::<String>(&[], &[]));
+    }
 
     #[test]
     fn test_check_not_blank() {


### PR DESCRIPTION
## Summary
This PR includes two maintenance commits:
1. **Add logging to server_list module and extract unordered_eq util**
   - Adds structured logging to `server_list` operations
   - Extracts `unordered_eq` utility for cleaner comparisons
2. **Fix clippy warnings on struct initialization**
   - Resolves clippy lint warnings by replacing `Default::default()` followed by field assignment with direct struct literal initialization
   - Covers both SDK code and examples (`aliyun_ram_app.rs`)

## Checklist
- [x] `cargo clippy --all-targets --all-features` passes cleanly
- [x] Code follows existing style conventions

Co-authored-by: OpenCode <opencode@opencode.ai>
Co-authored-by: Kimi-K2.6 <kimi@moonshot.ai>
Co-authored-by: GLM5.1 <glm5.1@zhipuai.cn>