### PR TITLE
chore: minimize dependency features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,11 @@ members = [
 default = ["config", "naming", "auth-by-http"]
 config = []
 naming = []
-tls = ["reqwest/default-tls", "tonic/transport", "tonic/tls-ring", "tonic/tls-native-roots"]
+tls = [
+    "reqwest/default-tls",
+    "tonic/tls-ring",
+    "tonic/tls-native-roots",
+]
 auth-by-http = []
 auth-by-aliyun = ["ring", "base64", "chrono"]
 # only need this if you don't customize tracing-subscriber
@@ -58,7 +62,7 @@ arc-swap = "1.9"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "time", "net", "fs"] }
 
-futures = "0.3"
+futures = { version = "0.3", default-features = false, features = ["async-await", "std"] }
 futures-util = "0.3"
 async-trait = "0.1"
 async-stream = "0.3"
@@ -79,13 +83,13 @@ url = "2"
 # only for aliyun-ram-auth
 ring = { version = "0.17", default-features = false, optional = true }
 base64 = { version = "0.22", default-features = false, optional = true }
-chrono = { version = "0.4", features = ["now"] ,optional = true }
+chrono = { version = "0.4", default-features = false, features = ["now"], optional = true }
 
 prost = "0.14"
 prost-types = "0.14"
-tonic = "0.14"
+tonic = { version = "0.14", default-features = false, features = ["channel", "codegen"] }
 tonic-prost = "0.14"
-tower = { version = "0.5", features = ["filter", "log"] }
+tower = { version = "0.5", features = ["buffer", "util"] }
 
 want = "0.3"
 dashmap = "6.1"

--- a/src/api/naming.rs
+++ b/src/api/naming.rs
@@ -76,7 +76,7 @@ impl ServiceInstance {
     }
 
     pub fn ip_and_port(&self) -> String {
-        format!("{}:{}", &self.ip, self.port)
+        format!("{}:{}", self.ip, self.port)
     }
 
     pub fn is_same_instance(&self, other: &ServiceInstance) -> bool {

--- a/src/naming/dto/service_info.rs
+++ b/src/naming/dto/service_info.rs
@@ -72,7 +72,7 @@ impl ServiceInfo {
 
     pub fn get_grouped_service_name(service_name: &str, group_name: &str) -> String {
         if !group_name.is_empty() && !service_name.contains(SERVICE_INFO_SEPARATOR) {
-            let service_name = format!("{}{}{}", &group_name, SERVICE_INFO_SEPARATOR, service_name);
+            let service_name = format!("{}{}{}", group_name, SERVICE_INFO_SEPARATOR, service_name);
             return service_name;
         }
         service_name.to_string()

--- a/src/naming/redo/mod.rs
+++ b/src/naming/redo/mod.rs
@@ -80,7 +80,7 @@ impl RedoTaskExecutor {
     #[instrument(fields(client_id = &self.id), skip_all)]
     pub(crate) async fn on_grpc_client_reconnect(&self) {
         let map = self.map.read().await;
-        for (_, v) in map.iter() {
+        for v in map.values() {
             v.active()
         }
     }
@@ -88,7 +88,7 @@ impl RedoTaskExecutor {
     #[instrument(fields(client_id = &self.id), skip_all)]
     pub(crate) async fn on_grpc_client_disconnect(&self) {
         let map = self.map.read().await;
-        for (_, v) in map.iter() {
+        for v in map.values() {
             v.frozen()
         }
     }


### PR DESCRIPTION
## Summary

- disable unused default features in `tonic`, `futures`, and `chrono`
- keep only the client-side `tonic` channel and code generation features
- declare the `tower` features used directly by the SDK

## Why

The SDK is a gRPC client, but `tonic` defaults also enabled its server and router stack. `futures` enabled its executor even though the SDK only uses future utilities, and Aliyun authentication only needs `chrono::Utc::now` rather than Chrono's full default feature set.

For the default build, this reduces the normal dependency graph from 135 to 128 packages while preserving existing behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --no-default-features --lib`
- `cargo check --no-default-features --features auth-by-aliyun --lib`
- `cargo check --all-features --lib`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --lib --bins --all-features` (97 passed, 21 ignored)
