### PR TITLE
feat: add config client lifecycle controls

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -140,6 +140,13 @@ impl ConfigService {
         crate::common::util::check_not_blank(&group, "group")?;
         self.inner.remove_listener(data_id, group, listener).await
     }
+
+    /// Stops this client's listeners, background tasks and transport connection.
+    ///
+    /// Calling `shutdown` more than once is safe. Disk caches are preserved.
+    pub async fn shutdown(&self) -> error::Result<()> {
+        self.inner.shutdown().await
+    }
 }
 
 /// The ConfigChangeListener receive notify of [`ConfigResponse`].

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -46,6 +46,9 @@ pub enum Error {
     #[error("remote client shutdown failed: {0}")]
     ClientShutdown(String),
 
+    #[error("request timed out after {0:?}")]
+    RequestTimeout(std::time::Duration),
+
     #[error("remote client unhealthy failed: {0}")]
     ClientUnhealthy(String),
 

--- a/src/api/props.rs
+++ b/src/api/props.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf, time::Duration};
 
 use crate::api::constants::*;
 use crate::properties::{get_value, get_value_bool, get_value_option};
@@ -23,6 +23,12 @@ pub struct ClientProps {
     naming_load_cache_at_start: bool,
     /// config load_cache_at_start, default false
     config_load_cache_at_start: bool,
+    /// Optional timeout for individual SDK requests.
+    request_timeout: Option<Duration>,
+    /// Optional timeout for establishing a gRPC connection.
+    connect_timeout: Option<Duration>,
+    /// Optional root directory for on-disk caches.
+    cache_dir: Option<PathBuf>,
     /// env_first when get props, default true
     env_first: bool,
     /// metadata
@@ -126,6 +132,18 @@ impl ClientProps {
         }
     }
 
+    pub(crate) fn get_request_timeout(&self) -> Option<Duration> {
+        self.request_timeout
+    }
+
+    pub(crate) fn get_connect_timeout(&self) -> Option<Duration> {
+        self.connect_timeout
+    }
+
+    pub(crate) fn get_cache_dir(&self) -> Option<PathBuf> {
+        self.cache_dir.clone()
+    }
+
     pub(crate) fn get_labels(&self) -> HashMap<String, String> {
         let mut labels = self.labels.clone();
         labels.insert(KEY_LABEL_APP_NAME.to_string(), self.get_app_name());
@@ -191,6 +209,9 @@ impl ClientProps {
             naming_push_empty_protection: true,
             naming_load_cache_at_start: false,
             config_load_cache_at_start: false,
+            request_timeout: None,
+            connect_timeout: None,
+            cache_dir: None,
             env_first: true,
             labels: HashMap::default(),
             client_version,
@@ -258,6 +279,30 @@ impl ClientProps {
     pub fn load_cache_at_start(mut self, load_cache_at_start: bool) -> Self {
         self.naming_load_cache_at_start = load_cache_at_start;
         self.config_load_cache_at_start = load_cache_at_start;
+        self
+    }
+
+    /// Sets the timeout for a single SDK request.
+    ///
+    /// Requests have no SDK-level timeout unless this is configured.
+    pub fn request_timeout(mut self, request_timeout: Duration) -> Self {
+        self.request_timeout = Some(request_timeout);
+        self
+    }
+
+    /// Sets the timeout for establishing a gRPC connection.
+    ///
+    /// Connection attempts have no SDK-level timeout unless this is configured.
+    pub fn connect_timeout(mut self, connect_timeout: Duration) -> Self {
+        self.connect_timeout = Some(connect_timeout);
+        self
+    }
+
+    /// Sets the root directory used for on-disk caches.
+    ///
+    /// The module and namespace directories are appended to this path.
+    pub fn cache_dir(mut self, cache_dir: impl Into<PathBuf>) -> Self {
+        self.cache_dir = Some(cache_dir.into());
         self
     }
 
@@ -342,6 +387,19 @@ mod tests {
     use crate::api::error::Error;
 
     use super::*;
+
+    #[test]
+    fn test_optional_client_controls() {
+        let cache_dir = std::env::temp_dir().join("nacos-sdk-cache");
+        let props = ClientProps::new()
+            .request_timeout(Duration::from_secs(2))
+            .connect_timeout(Duration::from_secs(4))
+            .cache_dir(cache_dir.clone());
+
+        assert_eq!(props.get_request_timeout(), Some(Duration::from_secs(2)));
+        assert_eq!(props.get_connect_timeout(), Some(Duration::from_secs(4)));
+        assert_eq!(props.get_cache_dir(), Some(cache_dir));
+    }
 
     #[tokio::test]
     async fn test_get_server_list() {

--- a/src/common/cache/mod.rs
+++ b/src/common/cache/mod.rs
@@ -378,13 +378,29 @@ pub mod tests {
             .await;
 
         cache.insert("key".to_string(), "value".to_string());
-        tokio::time::sleep(Duration::from_millis(250)).await;
 
         let cache_file = root.join("config").join("test-namespace").join("key");
-        let value = tokio::fs::read_to_string(&cache_file)
-            .await
-            .expect("custom cache file should be written");
+        let value = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if let Ok(value) = tokio::fs::read_to_string(&cache_file).await {
+                    break value;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("custom cache file should be written within timeout");
         assert_eq!(value, "\"value\"");
+
+        let reloaded: Cache<String> = CacheBuilder::config("test-namespace".to_string())
+            .load_cache_at_start(true)
+            .disk_store(Some(root.clone()))
+            .build()
+            .await;
+        let reloaded_value = reloaded
+            .get(&"key".to_string())
+            .expect("custom cache value should reload from disk");
+        assert_eq!(reloaded_value.as_str(), "value");
 
         tokio::fs::remove_dir_all(&root)
             .await

--- a/src/common/cache/mod.rs
+++ b/src/common/cache/mod.rs
@@ -218,11 +218,10 @@ where
         }
     }
 
-    pub(crate) fn disk_store(self) -> Self {
-        let user_home = std::path::PathBuf::from(crate::common::util::HOME_DIR.to_owned());
-
-        let mut disk_path = user_home;
-        disk_path.push("nacos");
+    pub(crate) fn disk_store(self, cache_dir: Option<std::path::PathBuf>) -> Self {
+        let mut disk_path = cache_dir.unwrap_or_else(|| {
+            std::path::PathBuf::from(crate::common::util::HOME_DIR.to_owned()).join("nacos")
+        });
         disk_path.push(self.module.clone());
         disk_path.push(self.namespace.clone());
 
@@ -271,7 +270,7 @@ pub mod tests {
 
         let cache: Cache<String> = CacheBuilder::naming("test-naming".to_string())
             .load_cache_at_start(true)
-            .disk_store()
+            .disk_store(None)
             .build()
             .await;
         let key = String::from("key");
@@ -354,7 +353,7 @@ pub mod tests {
 
         let cache: Cache<String> = CacheBuilder::naming("test-naming".to_string())
             .load_cache_at_start(true)
-            .disk_store()
+            .disk_store(None)
             .build()
             .await;
 
@@ -367,5 +366,28 @@ pub mod tests {
         tokio::fs::remove_file(&disk_path)
             .await
             .expect("Failed to remove test cache file");
+    }
+
+    #[tokio::test]
+    async fn test_custom_cache_dir() {
+        let root =
+            std::env::temp_dir().join(format!("nacos-sdk-custom-cache-{}", rand::random::<u64>()));
+        let cache: Cache<String> = CacheBuilder::config("test-namespace".to_string())
+            .disk_store(Some(root.clone()))
+            .build()
+            .await;
+
+        cache.insert("key".to_string(), "value".to_string());
+        tokio::time::sleep(Duration::from_millis(250)).await;
+
+        let cache_file = root.join("config").join("test-namespace").join("key");
+        let value = tokio::fs::read_to_string(&cache_file)
+            .await
+            .expect("custom cache file should be written");
+        assert_eq!(value, "\"value\"");
+
+        tokio::fs::remove_dir_all(&root)
+            .await
+            .expect("custom cache directory should be removable");
     }
 }

--- a/src/common/remote/grpc/nacos_grpc_client.rs
+++ b/src/common/remote/grpc/nacos_grpc_client.rs
@@ -411,13 +411,10 @@ impl NacosGrpcClientBuilder {
         let health_check_request = GrpcMessageBuilder::new(HealthCheckRequest::default())
             .build()
             .into_payload()?;
-        match send_request_with_timeout(
-            send_request.as_ref(),
-            health_check_request,
-            request_timeout,
-        )
-        .await
-        {
+        // This call also waits for connection initialization and retry backoff. Do not wrap the
+        // whole operation in the public request timeout; connect timeout still applies to each
+        // underlying connection attempt.
+        match send_request.send_request(health_check_request).await {
             Ok(_) => {
                 tracing::info!("health check passed, connected to Nacos server");
             }

--- a/src/common/remote/grpc/nacos_grpc_client.rs
+++ b/src/common/remote/grpc/nacos_grpc_client.rs
@@ -1,4 +1,11 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 use tower::layer::util::Stack;
 use tracing::{Instrument, instrument};
 
@@ -26,6 +33,7 @@ pub(crate) struct NacosGrpcClient {
     app_name: String,
     send_request: Arc<dyn SendRequest + Send + Sync + 'static>,
     auth_plugin: Arc<dyn AuthPlugin>,
+    shutdown: AtomicBool,
 }
 
 impl NacosGrpcClient {
@@ -38,6 +46,12 @@ impl NacosGrpcClient {
         Request: GrpcRequestMessage + 'static,
         Response: GrpcResponseMessage + 'static,
     {
+        if self.shutdown.load(Ordering::Acquire) {
+            return Err(Error::ClientShutdown(
+                "requests are not accepted after shutdown".to_string(),
+            ));
+        }
+
         let mut request_headers = request.take_headers();
         if let Some(resource) = request.request_resource() {
             let auth_context = self.auth_plugin.get_login_identity(resource);
@@ -58,6 +72,17 @@ impl NacosGrpcClient {
 
         let grpc_response = GrpcMessage::<Response>::from_payload(grpc_response)?;
         Ok(grpc_response.into_body())
+    }
+
+    pub(crate) fn is_shutdown(&self) -> bool {
+        self.shutdown.load(Ordering::Acquire)
+    }
+
+    pub(crate) async fn shutdown(&self) -> Result<(), Error> {
+        if self.shutdown.swap(true, Ordering::AcqRel) {
+            return Ok(());
+        }
+        self.send_request.shutdown().await
     }
 }
 
@@ -187,6 +212,11 @@ impl NacosGrpcClientBuilder {
         self
     }
 
+    pub(crate) fn request_timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.grpc_config.timeout = timeout;
+        self
+    }
+
     pub(crate) fn concurrency_limit(mut self, concurrency_limit: usize) -> Self {
         self.grpc_config.concurrency_limit = Some(concurrency_limit);
         self
@@ -234,6 +264,11 @@ impl NacosGrpcClientBuilder {
 
     pub(crate) fn connect_timeout(mut self, connect_timeout: Duration) -> Self {
         self.grpc_config.connect_timeout = Some(connect_timeout);
+        self
+    }
+
+    pub(crate) fn optional_connect_timeout(mut self, connect_timeout: Option<Duration>) -> Self {
+        self.grpc_config.connect_timeout = connect_timeout;
         self
     }
 
@@ -389,6 +424,7 @@ impl NacosGrpcClientBuilder {
             app_name,
             send_request,
             auth_plugin,
+            shutdown: AtomicBool::new(false),
         })
     }
 }
@@ -453,6 +489,7 @@ pub mod tests {
             app_name: "test_app".to_string(),
             send_request: Arc::new(mock_send_request),
             auth_plugin: Arc::new(NoopAuthPlugin::default()),
+            shutdown: AtomicBool::new(false),
         };
 
         let response = nacos_grpc_client
@@ -466,5 +503,35 @@ pub mod tests {
                 .request_id
                 .expect("Response request ID should exist")
         );
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_is_idempotent_and_rejects_requests() {
+        let mut mock_send_request = MockSendRequest::new();
+        mock_send_request
+            .expect_shutdown()
+            .times(1)
+            .returning(|| Ok(()));
+
+        let nacos_grpc_client = NacosGrpcClient {
+            app_name: "test_app".to_string(),
+            send_request: Arc::new(mock_send_request),
+            auth_plugin: Arc::new(NoopAuthPlugin::default()),
+            shutdown: AtomicBool::new(false),
+        };
+
+        nacos_grpc_client
+            .shutdown()
+            .await
+            .expect("first shutdown should succeed");
+        nacos_grpc_client
+            .shutdown()
+            .await
+            .expect("second shutdown should succeed");
+
+        let result = nacos_grpc_client
+            .send_request::<HealthCheckRequest, HealthCheckResponse>(HealthCheckRequest::default())
+            .await;
+        assert!(matches!(result, Err(Error::ClientShutdown(_))));
     }
 }

--- a/src/common/remote/grpc/nacos_grpc_client.rs
+++ b/src/common/remote/grpc/nacos_grpc_client.rs
@@ -33,7 +33,23 @@ pub(crate) struct NacosGrpcClient {
     app_name: String,
     send_request: Arc<dyn SendRequest + Send + Sync + 'static>,
     auth_plugin: Arc<dyn AuthPlugin>,
+    request_timeout: Option<Duration>,
     shutdown: AtomicBool,
+}
+
+async fn send_request_with_timeout(
+    send_request: &(dyn SendRequest + Send + Sync + 'static),
+    request: crate::nacos_proto::v2::Payload,
+    request_timeout: Option<Duration>,
+) -> Result<crate::nacos_proto::v2::Payload, Error> {
+    let request = send_request.send_request(request).in_current_span();
+    if let Some(timeout) = request_timeout {
+        tokio::time::timeout(timeout, request)
+            .await
+            .map_err(|_| Error::RequestTimeout(timeout))?
+    } else {
+        request.await
+    }
 }
 
 impl NacosGrpcClient {
@@ -64,11 +80,12 @@ impl NacosGrpcClient {
             .build();
         let grpc_request = grpc_request.into_payload()?;
 
-        let grpc_response = self
-            .send_request
-            .send_request(grpc_request)
-            .in_current_span()
-            .await?;
+        let grpc_response = send_request_with_timeout(
+            self.send_request.as_ref(),
+            grpc_request,
+            self.request_timeout,
+        )
+        .await?;
 
         let grpc_response = GrpcMessage::<Response>::from_payload(grpc_response)?;
         Ok(grpc_response.into_body())
@@ -354,6 +371,7 @@ impl NacosGrpcClientBuilder {
             Arc::new(ClientDetectionRequestHandler),
         );
 
+        let request_timeout = self.grpc_config.timeout;
         let send_request = {
             let server_list =
                 PollingServerListService::from_provider(self.server_list_provider.clone()).await;
@@ -393,7 +411,13 @@ impl NacosGrpcClientBuilder {
         let health_check_request = GrpcMessageBuilder::new(HealthCheckRequest::default())
             .build()
             .into_payload()?;
-        match send_request.send_request(health_check_request).await {
+        match send_request_with_timeout(
+            send_request.as_ref(),
+            health_check_request,
+            request_timeout,
+        )
+        .await
+        {
             Ok(_) => {
                 tracing::info!("health check passed, connected to Nacos server");
             }
@@ -424,6 +448,7 @@ impl NacosGrpcClientBuilder {
             app_name,
             send_request,
             auth_plugin,
+            request_timeout,
             shutdown: AtomicBool::new(false),
         })
     }
@@ -489,6 +514,7 @@ pub mod tests {
             app_name: "test_app".to_string(),
             send_request: Arc::new(mock_send_request),
             auth_plugin: Arc::new(NoopAuthPlugin::default()),
+            request_timeout: None,
             shutdown: AtomicBool::new(false),
         };
 
@@ -517,6 +543,7 @@ pub mod tests {
             app_name: "test_app".to_string(),
             send_request: Arc::new(mock_send_request),
             auth_plugin: Arc::new(NoopAuthPlugin::default()),
+            request_timeout: None,
             shutdown: AtomicBool::new(false),
         };
 
@@ -533,5 +560,39 @@ pub mod tests {
             .send_request::<HealthCheckRequest, HealthCheckResponse>(HealthCheckRequest::default())
             .await;
         assert!(matches!(result, Err(Error::ClientShutdown(_))));
+    }
+
+    struct PendingSendRequest;
+
+    #[async_trait::async_trait]
+    impl SendRequest for PendingSendRequest {
+        async fn send_request(
+            &self,
+            _request: crate::nacos_proto::v2::Payload,
+        ) -> Result<crate::nacos_proto::v2::Payload, Error> {
+            futures::future::pending().await
+        }
+
+        async fn shutdown(&self) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_request_timeout_covers_waiting_for_transport() {
+        let timeout = Duration::from_millis(20);
+        let client = NacosGrpcClient {
+            app_name: "test_app".to_string(),
+            send_request: Arc::new(PendingSendRequest),
+            auth_plugin: Arc::new(NoopAuthPlugin::default()),
+            request_timeout: Some(timeout),
+            shutdown: AtomicBool::new(false),
+        };
+
+        let result = client
+            .send_request::<HealthCheckRequest, HealthCheckResponse>(HealthCheckRequest::default())
+            .await;
+
+        assert!(matches!(result, Err(Error::RequestTimeout(value)) if value == timeout));
     }
 }

--- a/src/common/remote/grpc/nacos_grpc_connection.rs
+++ b/src/common/remote/grpc/nacos_grpc_connection.rs
@@ -39,6 +39,58 @@ type DisconnectedListener = Arc<dyn Fn(String) + Send + Sync + 'static>;
 type HandlerMap = HashMap<String, Arc<dyn ServerRequestHandler>>;
 const MAX_RETRY: u32 = 6;
 
+#[derive(Clone, Default)]
+struct TaskHandles {
+    inner: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+}
+
+impl TaskHandles {
+    fn track(&self, task: tokio::task::JoinHandle<()>) {
+        let mut tasks = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        tasks.retain(|task| !task.is_finished());
+        tasks.push(task);
+    }
+
+    fn abort_all(&self) {
+        let mut tasks = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for task in tasks.drain(..) {
+            task.abort();
+        }
+    }
+
+    async fn shutdown(&self) {
+        let tasks = {
+            let mut tasks = self
+                .inner
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            std::mem::take(&mut *tasks)
+        };
+        for task in &tasks {
+            task.abort();
+        }
+        for task in tasks {
+            let _ = task.await;
+        }
+    }
+}
+
+struct ConnectionInitContext {
+    client_version: String,
+    namespace: String,
+    labels: HashMap<String, String>,
+    client_abilities: NacosClientAbilities,
+    handler_map: Arc<HandlerMap>,
+    health: Arc<AtomicBool>,
+    tasks: TaskHandles,
+}
+
 fn sleep_time(retry_count: u32) -> u32 {
     if retry_count > MAX_RETRY {
         1 << MAX_RETRY
@@ -69,7 +121,7 @@ where
     max_retries: Option<u32>,
     is_initialized: bool,
     shutdown_watcher: (watch::Sender<bool>, watch::Receiver<bool>),
-    connection_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+    connection_tasks: TaskHandles,
 }
 
 impl<M> NacosGrpcConnection<M>
@@ -94,7 +146,7 @@ where
     ) -> Self {
         let connection_id_watcher = watch::channel(None);
         let shutdown_watcher = watch::channel(false);
-        let connection_tasks = Arc::new(Mutex::new(Vec::new()));
+        let connection_tasks = TaskHandles::default();
 
         Self {
             id,
@@ -134,7 +186,7 @@ where
             debug!("connected listener quit.");
         };
         let task = executor::spawn(watch_fu);
-        Self::track_connection_task(&self.connection_tasks, task);
+        self.connection_tasks.track(task);
         self
     }
 
@@ -156,7 +208,7 @@ where
             debug!("disconnect listener quit.");
         };
         let task = executor::spawn(watch_fu);
-        Self::track_connection_task(&self.connection_tasks, task);
+        self.connection_tasks.track(task);
         self
     }
 
@@ -170,37 +222,19 @@ where
         FailoverConnection::new(id, self, svc_health, shutdown_signal, connection_tasks)
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn init_connection(
         mut service: M::Service,
-        client_version: String,
-        namespace: String,
-        labels: HashMap<String, String>,
-        client_abilities: NacosClientAbilities,
-        handler_map: Arc<HandlerMap>,
-        health: Arc<AtomicBool>,
-        shutdown_rx: watch::Receiver<bool>,
-        connection_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+        context: ConnectionInitContext,
     ) -> Result<(M::Service, String), Error> {
         // setup
-        let conn_id_sender = NacosGrpcConnection::<M>::setup(
-            handler_map,
-            &mut service,
-            health,
-            client_version,
-            namespace,
-            labels,
-            client_abilities,
-            shutdown_rx,
-            connection_tasks.clone(),
-        )
-        .in_current_span()
-        .await?;
+        let conn_id_sender = NacosGrpcConnection::<M>::setup(&mut service, &context)
+            .in_current_span()
+            .await?;
 
         // connection health check
         for i in 0..4 {
             let health_check =
-                NacosGrpcConnection::<M>::connection_health_check(&mut service, &connection_tasks)
+                NacosGrpcConnection::<M>::connection_health_check(&mut service, &context.tasks)
                     .in_current_span()
                     .await;
             if health_check.is_err() {
@@ -211,7 +245,7 @@ where
         }
 
         // check server
-        let connection_id = NacosGrpcConnection::<M>::check_server(&mut service, &connection_tasks)
+        let connection_id = NacosGrpcConnection::<M>::check_server(&mut service, &context.tasks)
             .in_current_span()
             .await?;
 
@@ -228,33 +262,23 @@ where
         Ok((service, connection_id))
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn setup(
-        server_stream_handlers: Arc<HandlerMap>,
         service: &mut M::Service,
-        health: Arc<AtomicBool>,
-        client_version: String,
-        namespace: String,
-        labels: HashMap<String, String>,
-        client_abilities: NacosClientAbilities,
-        shutdown_rx: watch::Receiver<bool>,
-        connection_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+        context: &ConnectionInitContext,
     ) -> Result<oneshot::Sender<String>, Error> {
         info!("setup connection");
 
         let setup_request = ConnectionSetupRequest {
-            client_version,
-            labels,
-            tenant: namespace,
-            abilities: client_abilities,
+            client_version: context.client_version.clone(),
+            labels: context.labels.clone(),
+            tenant: context.namespace.clone(),
+            abilities: context.client_abilities.clone(),
             ..Default::default()
         };
 
         let (local_sender, mut local_receiver) = mpsc::channel::<Payload>(1024);
         let local_sender = Arc::new(local_sender);
         let local_sender_clone = local_sender.clone();
-        let mut local_shutdown_rx = shutdown_rx.clone();
-        let mut server_shutdown_rx = shutdown_rx;
 
         let payload = utils::convert(
             GrpcMessageBuilder::new(setup_request)
@@ -274,18 +298,9 @@ where
             // notify
             let _ = notifier.send(());
             debug!("open local stream.");
-            loop {
-                let shutdown = local_shutdown_rx.changed();
-                let request = local_receiver.recv();
-                futures::pin_mut!(shutdown, request);
-                match futures::future::select(shutdown, request).await {
-                    futures::future::Either::Left(_) => break,
-                    futures::future::Either::Right((request, _)) => {
-                        let Some(request) = request else { break };
-                        debug!("local stream send message to server");
-                        yield request;
-                    }
-                }
+            while let Some(request) = local_receiver.recv().await {
+                debug!("local stream send message to server");
+                yield request;
             }
             warn!("local stream closed!");
         }));
@@ -297,9 +312,11 @@ where
         let call_task = executor::spawn(async move {
             let _ = call.await;
         });
-        Self::track_connection_task(&connection_tasks, call_task);
+        context.tasks.track(call_task);
 
         let (conn_id_sender, conn_id_receiver) = oneshot::channel::<String>();
+        let server_stream_handlers = context.handler_map.clone();
+        let health = context.health.clone();
         let server_task = executor::spawn(
             async move {
                 tk.want();
@@ -330,15 +347,7 @@ where
                 let span = debug_span!("bi_stream", conn_id = conn_id);
                 async {
                     let mut server_stream = Box::pin(server_stream);
-                    loop {
-                        let shutdown = server_shutdown_rx.changed();
-                        let response = server_stream.next();
-                        futures::pin_mut!(shutdown, response);
-                        let response = match futures::future::select(shutdown, response).await {
-                            futures::future::Either::Left(_) => break,
-                            futures::future::Either::Right((response, _)) => response,
-                        };
-                        let Some(Ok(response)) = response else { break };
+                    while let Some(Ok(response)) = server_stream.next().await {
                         debug!("server stream receive message from server");
                         let Some(handler_key) = response
                             .metadata
@@ -374,26 +383,15 @@ where
             }
             .in_current_span(),
         );
-        Self::track_connection_task(&connection_tasks, server_task);
+        context.tasks.track(server_task);
 
         let _ = waiter.await;
         Ok(conn_id_sender)
     }
 
-    fn track_connection_task(
-        tasks: &Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
-        task: tokio::task::JoinHandle<()>,
-    ) {
-        let mut tasks = tasks
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        tasks.retain(|task| !task.is_finished());
-        tasks.push(task);
-    }
-
     async fn connection_health_check(
         service: &mut M::Service,
-        connection_tasks: &Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+        connection_tasks: &TaskHandles,
     ) -> Result<(), Error> {
         info!("connection health check");
 
@@ -410,7 +408,7 @@ where
         let task = executor::spawn(async move {
             let _ = call.await;
         });
-        Self::track_connection_task(connection_tasks, task);
+        connection_tasks.track(task);
 
         tk.want();
         let response = utils::convert(
@@ -433,7 +431,7 @@ where
 
     async fn check_server(
         service: &mut M::Service,
-        connection_tasks: &Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+        connection_tasks: &TaskHandles,
     ) -> Result<String, Error> {
         info!("check server");
 
@@ -450,7 +448,7 @@ where
         let task = executor::spawn(async move {
             let _ = call.await;
         });
-        Self::track_connection_task(connection_tasks, task);
+        connection_tasks.track(task);
 
         tk.want();
         let response = utils::convert(
@@ -547,17 +545,17 @@ where
                     match ret {
                         Poll::Pending => return Poll::Pending,
                         Poll::Ready(Ok(ret)) => {
-                            let init_future = Box::pin(NacosGrpcConnection::<M>::init_connection(
-                                ret,
-                                self.client_version.clone(),
-                                self.namespace.clone(),
-                                self.labels.clone(),
-                                self.client_abilities.clone(),
-                                self.handler_map.clone(),
-                                self.health.clone(),
-                                self.shutdown_watcher.1.clone(),
-                                self.connection_tasks.clone(),
-                            ));
+                            let context = ConnectionInitContext {
+                                client_version: self.client_version.clone(),
+                                namespace: self.namespace.clone(),
+                                labels: self.labels.clone(),
+                                client_abilities: self.client_abilities.clone(),
+                                handler_map: self.handler_map.clone(),
+                                health: self.health.clone(),
+                                tasks: self.connection_tasks.clone(),
+                            };
+                            let init_future =
+                                Box::pin(NacosGrpcConnection::<M>::init_connection(ret, context));
                             self.state = State::Initializing(init_future);
                             continue;
                         }
@@ -698,7 +696,7 @@ where
                 let task = executor::spawn(async move {
                     let _ = call_task.await;
                 });
-                Self::track_connection_task(&connection_tasks, task);
+                connection_tasks.track(task);
                 ResponseFuture::new(response_fut)
             }
             _ => {
@@ -746,10 +744,9 @@ where
     id: String,
     inner: Mutex<Option<Buffer<Payload, S::Future>>>,
     svc_health: Arc<AtomicBool>,
-    active_health_check: Arc<AtomicBool>,
     shutdown_signal: watch::Sender<bool>,
-    background_tasks: Mutex<Vec<tokio::task::JoinHandle<()>>>,
-    connection_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+    background_tasks: TaskHandles,
+    connection_tasks: TaskHandles,
 }
 
 impl<S> FailoverConnection<S>
@@ -757,35 +754,31 @@ where
     S: Service<Payload, Error = Error, Response = Payload> + Send + 'static,
     S::Future: Send + 'static,
 {
-    pub(crate) fn new(
+    fn new(
         id: String,
         svc: S,
         svc_health: Arc<AtomicBool>,
         shutdown_signal: watch::Sender<bool>,
-        connection_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+        connection_tasks: TaskHandles,
     ) -> Self {
         let (inner, work) = Buffer::pair(svc, 1024);
+        let background_tasks = TaskHandles::default();
         let worker_task = executor::spawn(work);
-
-        let active_health_check = Arc::new(AtomicBool::new(true));
+        background_tasks.track(worker_task);
 
         // start health check task
         let health_task = executor::spawn(
-            FailoverConnection::<S>::health_check(
-                inner.clone(),
-                active_health_check.clone(),
-                svc_health.clone(),
-            )
-            .instrument(debug_span!("health_check", id = id)),
+            FailoverConnection::<S>::health_check(inner.clone(), svc_health.clone())
+                .instrument(debug_span!("health_check", id = id)),
         );
+        background_tasks.track(health_task);
 
         Self {
             id,
             inner: Mutex::new(Some(inner)),
             svc_health,
-            active_health_check,
             shutdown_signal,
-            background_tasks: Mutex::new(vec![worker_task, health_task]),
+            background_tasks,
             connection_tasks,
         }
     }
@@ -798,12 +791,8 @@ where
             .compare_exchange(true, false, Ordering::SeqCst, Ordering::Acquire);
     }
 
-    async fn health_check(
-        mut svc: Buffer<Payload, S::Future>,
-        active_health_check: Arc<AtomicBool>,
-        svc_health: Arc<AtomicBool>,
-    ) {
-        while active_health_check.load(Ordering::Acquire) {
+    async fn health_check(mut svc: Buffer<Payload, S::Future>, svc_health: Arc<AtomicBool>) {
+        loop {
             debug!("health check.");
             let Ok(health_check_request) = GrpcMessageBuilder::new(HealthCheckRequest::default())
                 .build()
@@ -840,8 +829,6 @@ where
 
             sleep(Duration::from_secs(5)).await;
         }
-
-        warn!("stop health check task.");
     }
 }
 
@@ -851,21 +838,12 @@ where
     S::Future: Send + 'static,
 {
     fn drop(&mut self) {
-        self.active_health_check.store(false, Ordering::Release);
         let _ = self.shutdown_signal.send(true);
         if let Ok(inner) = self.inner.get_mut() {
             inner.take();
         }
-        if let Ok(tasks) = self.background_tasks.get_mut() {
-            for task in tasks.drain(..) {
-                task.abort();
-            }
-        }
-        if let Ok(mut tasks) = self.connection_tasks.lock() {
-            for task in tasks.drain(..) {
-                task.abort();
-            }
-        }
+        self.background_tasks.abort_all();
+        self.connection_tasks.abort_all();
     }
 }
 
@@ -909,7 +887,6 @@ where
         if *self.shutdown_signal.borrow() {
             return Ok(());
         }
-        self.active_health_check.store(false, Ordering::Release);
         self.svc_health.store(false, Ordering::Release);
         let _ = self.shutdown_signal.send(true);
 
@@ -917,32 +894,8 @@ where
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .take();
-        let tasks = {
-            let mut tasks = self
-                .background_tasks
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            std::mem::take(&mut *tasks)
-        };
-        for task in &tasks {
-            task.abort();
-        }
-        for task in tasks {
-            let _ = task.await;
-        }
-        let connection_tasks = {
-            let mut tasks = self
-                .connection_tasks
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            std::mem::take(&mut *tasks)
-        };
-        for task in &connection_tasks {
-            task.abort();
-        }
-        for task in connection_tasks {
-            let _ = task.await;
-        }
+        self.background_tasks.shutdown().await;
+        self.connection_tasks.shutdown().await;
         Ok(())
     }
 }
@@ -1072,7 +1025,8 @@ pub mod nacos_grpc_connection_tests {
             let _task_guard = task_guard;
             futures::future::pending::<()>().await;
         });
-        let connection_tasks = Arc::new(Mutex::new(vec![connection_task]));
+        let connection_tasks = TaskHandles::default();
+        connection_tasks.track(connection_task);
         let connection = FailoverConnection::new(
             "test-client".to_string(),
             DroppingService {

--- a/src/common/remote/grpc/nacos_grpc_connection.rs
+++ b/src/common/remote/grpc/nacos_grpc_connection.rs
@@ -1,7 +1,11 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::Poll;
 use std::time::Duration;
-use std::{collections::HashMap, pin::Pin, sync::Arc};
+use std::{
+    collections::HashMap,
+    pin::Pin,
+    sync::{Arc, Mutex},
+};
 
 use async_stream::stream;
 use async_trait::async_trait;
@@ -65,6 +69,7 @@ where
     max_retries: Option<u32>,
     is_initialized: bool,
     shutdown_watcher: (watch::Sender<bool>, watch::Receiver<bool>),
+    connection_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
 }
 
 impl<M> NacosGrpcConnection<M>
@@ -89,6 +94,7 @@ where
     ) -> Self {
         let connection_id_watcher = watch::channel(None);
         let shutdown_watcher = watch::channel(false);
+        let connection_tasks = Arc::new(Mutex::new(Vec::new()));
 
         Self {
             id,
@@ -106,6 +112,7 @@ where
             max_retries,
             is_initialized: false,
             shutdown_watcher,
+            connection_tasks,
         }
     }
 
@@ -126,7 +133,8 @@ where
             }
             debug!("connected listener quit.");
         };
-        executor::spawn(watch_fu);
+        let task = executor::spawn(watch_fu);
+        Self::track_connection_task(&self.connection_tasks, task);
         self
     }
 
@@ -147,7 +155,8 @@ where
             }
             debug!("disconnect listener quit.");
         };
-        executor::spawn(watch_fu);
+        let task = executor::spawn(watch_fu);
+        Self::track_connection_task(&self.connection_tasks, task);
         self
     }
 
@@ -157,7 +166,14 @@ where
     ) -> FailoverConnection<NacosGrpcConnection<M>> {
         let svc_health = self.health.clone();
         let shutdown_signal = self.shutdown_watcher.0.clone();
-        FailoverConnection::new(id, self, svc_health, shutdown_signal)
+        let connection_tasks = self.connection_tasks.clone();
+        FailoverConnection::new(
+            id,
+            self,
+            svc_health,
+            shutdown_signal,
+            connection_tasks,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -170,6 +186,7 @@ where
         handler_map: Arc<HandlerMap>,
         health: Arc<AtomicBool>,
         shutdown_rx: watch::Receiver<bool>,
+        connection_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
     ) -> Result<(M::Service, String), Error> {
         // setup
         let conn_id_sender = NacosGrpcConnection::<M>::setup(
@@ -181,15 +198,19 @@ where
             labels,
             client_abilities,
             shutdown_rx,
+            connection_tasks.clone(),
         )
         .in_current_span()
         .await?;
 
         // connection health check
         for i in 0..4 {
-            let health_check = NacosGrpcConnection::<M>::connection_health_check(&mut service)
-                .in_current_span()
-                .await;
+            let health_check = NacosGrpcConnection::<M>::connection_health_check(
+                &mut service,
+                &connection_tasks,
+            )
+            .in_current_span()
+            .await;
             if health_check.is_err() {
                 sleep(Duration::from_millis(300 << i)).await;
                 continue;
@@ -198,9 +219,10 @@ where
         }
 
         // check server
-        let connection_id = NacosGrpcConnection::<M>::check_server(&mut service)
-            .in_current_span()
-            .await?;
+        let connection_id =
+            NacosGrpcConnection::<M>::check_server(&mut service, &connection_tasks)
+                .in_current_span()
+                .await?;
 
         let conn_id_send_ret = conn_id_sender.send(connection_id.clone());
         if let Err(e) = conn_id_send_ret {
@@ -225,6 +247,7 @@ where
         labels: HashMap<String, String>,
         client_abilities: NacosClientAbilities,
         shutdown_rx: watch::Receiver<bool>,
+        connection_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
     ) -> Result<oneshot::Sender<String>, Error> {
         info!("setup connection");
 
@@ -279,10 +302,14 @@ where
         let (cb, rx, mut tk) =
             utils::create_grpc_callback::<Result<GrpcStream<Result<Payload, Error>>, Error>>();
         let call = NacosGrpcCall::BIRequestService((local_stream, cb));
-        executor::spawn(service.call(call).in_current_span());
+        let call = service.call(call).in_current_span();
+        let call_task = executor::spawn(async move {
+            let _ = call.await;
+        });
+        Self::track_connection_task(&connection_tasks, call_task);
 
         let (conn_id_sender, conn_id_receiver) = oneshot::channel::<String>();
-        executor::spawn(
+        let server_task = executor::spawn(
             async move {
                 tk.want();
                 let server_stream =
@@ -356,12 +383,27 @@ where
             }
             .in_current_span(),
         );
+        Self::track_connection_task(&connection_tasks, server_task);
 
         let _ = waiter.await;
         Ok(conn_id_sender)
     }
 
-    async fn connection_health_check(service: &mut M::Service) -> Result<(), Error> {
+    fn track_connection_task(
+        tasks: &Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+        task: tokio::task::JoinHandle<()>,
+    ) {
+        let mut tasks = tasks
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        tasks.retain(|task| !task.is_finished());
+        tasks.push(task);
+    }
+
+    async fn connection_health_check(
+        service: &mut M::Service,
+        connection_tasks: &Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+    ) -> Result<(), Error> {
         info!("connection health check");
 
         let request = utils::convert(
@@ -373,7 +415,11 @@ where
 
         let (cb, rx, mut tk) = utils::create_grpc_callback::<Result<Payload, Error>>();
         let grpc_call = NacosGrpcCall::RequestService((request, cb));
-        executor::spawn(service.call(grpc_call));
+        let call = service.call(grpc_call);
+        let task = executor::spawn(async move {
+            let _ = call.await;
+        });
+        Self::track_connection_task(connection_tasks, task);
 
         tk.want();
         let response = utils::convert(
@@ -394,7 +440,10 @@ where
         Ok(())
     }
 
-    async fn check_server(service: &mut M::Service) -> Result<String, Error> {
+    async fn check_server(
+        service: &mut M::Service,
+        connection_tasks: &Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+    ) -> Result<String, Error> {
         info!("check server");
 
         let request = utils::convert(
@@ -406,7 +455,11 @@ where
 
         let (cb, rx, mut tk) = utils::create_grpc_callback::<Result<Payload, Error>>();
         let grpc_call = NacosGrpcCall::RequestService((request, cb));
-        executor::spawn(service.call(grpc_call));
+        let call = service.call(grpc_call);
+        let task = executor::spawn(async move {
+            let _ = call.await;
+        });
+        Self::track_connection_task(connection_tasks, task);
 
         tk.want();
         let response = utils::convert(
@@ -510,6 +563,7 @@ where
                                 self.handler_map.clone(),
                                 self.health.clone(),
                                 self.shutdown_watcher.1.clone(),
+                                self.connection_tasks.clone(),
                             ));
                             self.state = State::Initializing(init_future);
                             continue;
@@ -634,6 +688,7 @@ where
         } else {
             "None".to_string()
         };
+        let connection_tasks = self.connection_tasks.clone();
 
         let _span_enter = debug_span!("grpc_connection", conn_id = conn_id).entered();
 
@@ -647,7 +702,10 @@ where
                     utils::recv_response(rx.await, "sender has been drop")?
                 }
                 .in_current_span();
-                executor::spawn(call_task);
+                let task = executor::spawn(async move {
+                    let _ = call_task.await;
+                });
+                Self::track_connection_task(&connection_tasks, task);
                 ResponseFuture::new(response_fut)
             }
             _ => {
@@ -693,10 +751,12 @@ where
     S::Future: Send + 'static,
 {
     id: String,
-    inner: Buffer<Payload, S::Future>,
+    inner: Mutex<Option<Buffer<Payload, S::Future>>>,
     svc_health: Arc<AtomicBool>,
     active_health_check: Arc<AtomicBool>,
     shutdown_signal: watch::Sender<bool>,
+    background_tasks: Mutex<Vec<tokio::task::JoinHandle<()>>>,
+    connection_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
 }
 
 impl<S> FailoverConnection<S>
@@ -709,14 +769,15 @@ where
         svc: S,
         svc_health: Arc<AtomicBool>,
         shutdown_signal: watch::Sender<bool>,
+        connection_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
     ) -> Self {
         let (inner, work) = Buffer::pair(svc, 1024);
-        executor::spawn(work);
+        let worker_task = executor::spawn(work);
 
         let active_health_check = Arc::new(AtomicBool::new(true));
 
         // start health check task
-        executor::spawn(
+        let health_task = executor::spawn(
             FailoverConnection::<S>::health_check(
                 inner.clone(),
                 active_health_check.clone(),
@@ -727,10 +788,12 @@ where
 
         Self {
             id,
-            inner,
+            inner: Mutex::new(Some(inner)),
             svc_health,
             active_health_check,
             shutdown_signal,
+            background_tasks: Mutex::new(vec![worker_task, health_task]),
+            connection_tasks,
         }
     }
 
@@ -796,6 +859,20 @@ where
 {
     fn drop(&mut self) {
         self.active_health_check.store(false, Ordering::Release);
+        let _ = self.shutdown_signal.send(true);
+        if let Ok(inner) = self.inner.get_mut() {
+            inner.take();
+        }
+        if let Ok(tasks) = self.background_tasks.get_mut() {
+            for task in tasks.drain(..) {
+                task.abort();
+            }
+        }
+        if let Ok(mut tasks) = self.connection_tasks.lock() {
+            for task in tasks.drain(..) {
+                task.abort();
+            }
+        }
     }
 }
 
@@ -821,7 +898,13 @@ where
                 "transport has been shut down".to_string(),
             ));
         }
-        let mut svc = self.inner.clone();
+        let mut svc = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| Error::ClientShutdown("transport has been shut down".to_string()))?;
         let _ = future::poll_fn(|cx| svc.poll_ready(cx))
             .in_current_span()
             .await?;
@@ -836,6 +919,37 @@ where
         self.active_health_check.store(false, Ordering::Release);
         self.svc_health.store(false, Ordering::Release);
         let _ = self.shutdown_signal.send(true);
+
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        let tasks = {
+            let mut tasks = self
+                .background_tasks
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            std::mem::take(&mut *tasks)
+        };
+        for task in &tasks {
+            task.abort();
+        }
+        for task in tasks {
+            let _ = task.await;
+        }
+        let connection_tasks = {
+            let mut tasks = self
+                .connection_tasks
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            std::mem::take(&mut *tasks)
+        };
+        for task in &connection_tasks {
+            task.abort();
+        }
+        for task in connection_tasks {
+            let _ = task.await;
+        }
         Ok(())
     }
 }
@@ -883,5 +997,74 @@ pub mod nacos_grpc_connection_tests {
             fn call(&mut self, request: ()) -> <Self as Service<()>>::Future;
 
         }
+    }
+
+    struct DroppingService {
+        dropped: Arc<AtomicBool>,
+    }
+
+    struct DropFlag(Arc<AtomicBool>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::Release);
+        }
+    }
+
+    impl Drop for DroppingService {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::Release);
+        }
+    }
+
+    impl Service<Payload> for DroppingService {
+        type Response = Payload;
+        type Error = Error;
+        type Future = ResponseFuture;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _request: Payload) -> Self::Future {
+            ResponseFuture::new(futures::future::pending())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_drops_transport_worker_and_rejects_requests() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let connection_task_dropped = Arc::new(AtomicBool::new(false));
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let task_guard = DropFlag(connection_task_dropped.clone());
+        let connection_task = executor::spawn(async move {
+            let _task_guard = task_guard;
+            futures::future::pending::<()>().await;
+        });
+        let connection_tasks = Arc::new(Mutex::new(vec![connection_task]));
+        let connection = FailoverConnection::new(
+            "test-client".to_string(),
+            DroppingService {
+                dropped: dropped.clone(),
+            },
+            Arc::new(AtomicBool::new(true)),
+            shutdown_tx,
+            connection_tasks,
+        );
+
+        connection
+            .shutdown()
+            .await
+            .expect("shutdown should succeed");
+        connection
+            .shutdown()
+            .await
+            .expect("repeated shutdown should succeed");
+
+        assert!(dropped.load(Ordering::Acquire));
+        assert!(connection_task_dropped.load(Ordering::Acquire));
+        assert!(*shutdown_rx.borrow());
+        let result = connection.send_request(Payload::default()).await;
+        assert!(matches!(result, Err(Error::ClientShutdown(_))));
     }
 }

--- a/src/common/remote/grpc/nacos_grpc_connection.rs
+++ b/src/common/remote/grpc/nacos_grpc_connection.rs
@@ -64,6 +64,7 @@ where
     ),
     max_retries: Option<u32>,
     is_initialized: bool,
+    shutdown_watcher: (watch::Sender<bool>, watch::Receiver<bool>),
 }
 
 impl<M> NacosGrpcConnection<M>
@@ -87,6 +88,7 @@ where
         max_retries: Option<u32>,
     ) -> Self {
         let connection_id_watcher = watch::channel(None);
+        let shutdown_watcher = watch::channel(false);
 
         Self {
             id,
@@ -103,6 +105,7 @@ where
             connection_id_watcher,
             max_retries,
             is_initialized: false,
+            shutdown_watcher,
         }
     }
 
@@ -153,9 +156,11 @@ where
         id: String,
     ) -> FailoverConnection<NacosGrpcConnection<M>> {
         let svc_health = self.health.clone();
-        FailoverConnection::new(id, self, svc_health)
+        let shutdown_signal = self.shutdown_watcher.0.clone();
+        FailoverConnection::new(id, self, svc_health, shutdown_signal)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn init_connection(
         mut service: M::Service,
         client_version: String,
@@ -164,6 +169,7 @@ where
         client_abilities: NacosClientAbilities,
         handler_map: Arc<HandlerMap>,
         health: Arc<AtomicBool>,
+        shutdown_rx: watch::Receiver<bool>,
     ) -> Result<(M::Service, String), Error> {
         // setup
         let conn_id_sender = NacosGrpcConnection::<M>::setup(
@@ -174,6 +180,7 @@ where
             namespace,
             labels,
             client_abilities,
+            shutdown_rx,
         )
         .in_current_span()
         .await?;
@@ -208,6 +215,7 @@ where
         Ok((service, connection_id))
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn setup(
         server_stream_handlers: Arc<HandlerMap>,
         service: &mut M::Service,
@@ -216,6 +224,7 @@ where
         namespace: String,
         labels: HashMap<String, String>,
         client_abilities: NacosClientAbilities,
+        shutdown_rx: watch::Receiver<bool>,
     ) -> Result<oneshot::Sender<String>, Error> {
         info!("setup connection");
 
@@ -230,6 +239,8 @@ where
         let (local_sender, mut local_receiver) = mpsc::channel::<Payload>(1024);
         let local_sender = Arc::new(local_sender);
         let local_sender_clone = local_sender.clone();
+        let mut local_shutdown_rx = shutdown_rx.clone();
+        let mut server_shutdown_rx = shutdown_rx;
 
         let payload = utils::convert(
             GrpcMessageBuilder::new(setup_request)
@@ -249,9 +260,18 @@ where
             // notify
             let _ = notifier.send(());
             debug!("open local stream.");
-            while let Some(request) = local_receiver.recv().await {
-                debug!("local stream send message to server");
-                yield request
+            loop {
+                let shutdown = local_shutdown_rx.changed();
+                let request = local_receiver.recv();
+                futures::pin_mut!(shutdown, request);
+                match futures::future::select(shutdown, request).await {
+                    futures::future::Either::Left(_) => break,
+                    futures::future::Either::Right((request, _)) => {
+                        let Some(request) = request else { break };
+                        debug!("local stream send message to server");
+                        yield request;
+                    }
+                }
             }
             warn!("local stream closed!");
         }));
@@ -292,7 +312,15 @@ where
                 let span = debug_span!("bi_stream", conn_id = conn_id);
                 async {
                     let mut server_stream = Box::pin(server_stream);
-                    while let Some(Ok(response)) = server_stream.next().await {
+                    loop {
+                        let shutdown = server_shutdown_rx.changed();
+                        let response = server_stream.next();
+                        futures::pin_mut!(shutdown, response);
+                        let response = match futures::future::select(shutdown, response).await {
+                            futures::future::Either::Left(_) => break,
+                            futures::future::Either::Right((response, _)) => response,
+                        };
+                        let Some(Ok(response)) = response else { break };
                         debug!("server stream receive message from server");
                         let Some(handler_key) = response
                             .metadata
@@ -430,6 +458,12 @@ where
         let _span_enter =
             debug_span!(parent: None, "grpc_connection", id = self.id.clone()).entered();
 
+        if *self.shutdown_watcher.1.borrow() {
+            return Poll::Ready(Err(Error::ClientShutdown(
+                "transport has been shut down".to_string(),
+            )));
+        }
+
         loop {
             if !self.is_initialized {
                 let max_retries = self.max_retries.unwrap_or(1);
@@ -475,6 +509,7 @@ where
                                 self.client_abilities.clone(),
                                 self.handler_map.clone(),
                                 self.health.clone(),
+                                self.shutdown_watcher.1.clone(),
                             ));
                             self.state = State::Initializing(init_future);
                             continue;
@@ -586,6 +621,14 @@ where
     }
 
     fn call(&mut self, req: Payload) -> Self::Future {
+        if *self.shutdown_watcher.1.borrow() {
+            return ResponseFuture::new(async {
+                Err(Error::ClientShutdown(
+                    "transport has been shut down".to_string(),
+                ))
+            });
+        }
+
         let conn_id = if let Some(ref conn_id) = self.connection_id {
             conn_id.clone()
         } else {
@@ -653,6 +696,7 @@ where
     inner: Buffer<Payload, S::Future>,
     svc_health: Arc<AtomicBool>,
     active_health_check: Arc<AtomicBool>,
+    shutdown_signal: watch::Sender<bool>,
 }
 
 impl<S> FailoverConnection<S>
@@ -660,7 +704,12 @@ where
     S: Service<Payload, Error = Error, Response = Payload> + Send + 'static,
     S::Future: Send + 'static,
 {
-    pub(crate) fn new(id: String, svc: S, svc_health: Arc<AtomicBool>) -> Self {
+    pub(crate) fn new(
+        id: String,
+        svc: S,
+        svc_health: Arc<AtomicBool>,
+        shutdown_signal: watch::Sender<bool>,
+    ) -> Self {
         let (inner, work) = Buffer::pair(svc, 1024);
         executor::spawn(work);
 
@@ -681,6 +730,7 @@ where
             inner,
             svc_health,
             active_health_check,
+            shutdown_signal,
         }
     }
 
@@ -754,6 +804,8 @@ where
 #[async_trait]
 pub(crate) trait SendRequest: Send {
     async fn send_request(&self, request: Payload) -> Result<Payload, Error>;
+
+    async fn shutdown(&self) -> Result<(), Error>;
 }
 
 #[async_trait]
@@ -764,12 +816,27 @@ where
 {
     #[instrument(fields(id = self.id), skip_all)]
     async fn send_request(&self, request: Payload) -> Result<Payload, Error> {
+        if *self.shutdown_signal.borrow() {
+            return Err(Error::ClientShutdown(
+                "transport has been shut down".to_string(),
+            ));
+        }
         let mut svc = self.inner.clone();
         let _ = future::poll_fn(|cx| svc.poll_ready(cx))
             .in_current_span()
             .await?;
         let ret = svc.call(request).in_current_span().await;
         ret.map_err(GrpcBufferRequest)
+    }
+
+    async fn shutdown(&self) -> Result<(), Error> {
+        if *self.shutdown_signal.borrow() {
+            return Ok(());
+        }
+        self.active_health_check.store(false, Ordering::Release);
+        self.svc_health.store(false, Ordering::Release);
+        let _ = self.shutdown_signal.send(true);
+        Ok(())
     }
 }
 

--- a/src/common/remote/grpc/nacos_grpc_connection.rs
+++ b/src/common/remote/grpc/nacos_grpc_connection.rs
@@ -502,13 +502,15 @@ where
         let _span_enter =
             debug_span!(parent: None, "grpc_connection", id = self.id.clone()).entered();
 
-        if *self.shutdown_watcher.1.borrow() {
-            return Poll::Ready(Err(Error::ClientShutdown(
-                "transport has been shut down".to_string(),
-            )));
-        }
-
         loop {
+            // State transitions can complete synchronously in one poll. Re-check here so a
+            // concurrent shutdown cannot advance a reconnect into initialization.
+            if *self.shutdown_watcher.1.borrow() {
+                return Poll::Ready(Err(Error::ClientShutdown(
+                    "transport has been shut down".to_string(),
+                )));
+            }
+
             if !self.is_initialized {
                 let max_retries = self.max_retries.unwrap_or(1);
                 if self.retry_count >= max_retries {
@@ -1020,6 +1022,44 @@ pub mod nacos_grpc_connection_tests {
         fn call(&mut self, _request: Payload) -> Self::Future {
             ResponseFuture::new(futures::future::pending())
         }
+    }
+
+    #[test]
+    fn test_poll_ready_rechecks_shutdown_after_state_transition() {
+        let shutdown_sender = Arc::new(Mutex::new(None::<watch::Sender<bool>>));
+        let shutdown_sender_for_make = shutdown_sender.clone();
+        let mut builder = MockTonicBuilder::new();
+        builder.expect_call().once().returning(move |_| {
+            shutdown_sender_for_make
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .as_ref()
+                .expect("shutdown sender should be initialized")
+                .send(true)
+                .expect("shutdown signal should be delivered");
+            Box::pin(future::pending())
+        });
+
+        let mut connection = NacosGrpcConnection::new(
+            "test-client".to_string(),
+            builder,
+            HashMap::new(),
+            "test-version".to_string(),
+            String::new(),
+            HashMap::new(),
+            NacosClientAbilities::default(),
+            Some(1),
+        );
+        *shutdown_sender
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            Some(connection.shutdown_watcher.0.clone());
+
+        let waker = futures::task::noop_waker();
+        let mut context = Context::from_waker(&waker);
+        let result = connection.poll_ready(&mut context);
+
+        assert!(matches!(result, Poll::Ready(Err(Error::ClientShutdown(_)))));
     }
 
     #[tokio::test]

--- a/src/common/remote/grpc/nacos_grpc_connection.rs
+++ b/src/common/remote/grpc/nacos_grpc_connection.rs
@@ -167,13 +167,7 @@ where
         let svc_health = self.health.clone();
         let shutdown_signal = self.shutdown_watcher.0.clone();
         let connection_tasks = self.connection_tasks.clone();
-        FailoverConnection::new(
-            id,
-            self,
-            svc_health,
-            shutdown_signal,
-            connection_tasks,
-        )
+        FailoverConnection::new(id, self, svc_health, shutdown_signal, connection_tasks)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -205,12 +199,10 @@ where
 
         // connection health check
         for i in 0..4 {
-            let health_check = NacosGrpcConnection::<M>::connection_health_check(
-                &mut service,
-                &connection_tasks,
-            )
-            .in_current_span()
-            .await;
+            let health_check =
+                NacosGrpcConnection::<M>::connection_health_check(&mut service, &connection_tasks)
+                    .in_current_span()
+                    .await;
             if health_check.is_err() {
                 sleep(Duration::from_millis(300 << i)).await;
                 continue;
@@ -219,10 +211,9 @@ where
         }
 
         // check server
-        let connection_id =
-            NacosGrpcConnection::<M>::check_server(&mut service, &connection_tasks)
-                .in_current_span()
-                .await?;
+        let connection_id = NacosGrpcConnection::<M>::check_server(&mut service, &connection_tasks)
+            .in_current_span()
+            .await?;
 
         let conn_id_send_ret = conn_id_sender.send(connection_id.clone());
         if let Err(e) = conn_id_send_ret {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -47,6 +47,20 @@ const MODULE_NAME: &str = "config";
 static SEQ: AtomicU64 = AtomicU64::new(1);
 
 impl NacosConfigService {
+    fn ensure_running(&self) -> crate::api::error::Result<()> {
+        if self.client_worker.is_shutdown() {
+            Err(crate::api::error::Error::ClientShutdown(
+                "config service has been shut down".to_string(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) async fn shutdown(&self) -> crate::api::error::Result<()> {
+        self.client_worker.shutdown().await
+    }
+
     pub async fn new(
         client_props: ClientProps,
         auth_plugin: std::sync::Arc<dyn AuthPlugin>,
@@ -74,6 +88,7 @@ impl NacosConfigService {
         data_id: String,
         group: String,
     ) -> crate::api::error::Result<crate::api::config::ConfigResponse> {
+        self.ensure_running()?;
         self.client_worker.get_config(data_id, group).await
     }
 
@@ -85,6 +100,7 @@ impl NacosConfigService {
         content: String,
         content_type: Option<String>,
     ) -> crate::api::error::Result<bool> {
+        self.ensure_running()?;
         self.client_worker
             .publish_config(data_id, group, content, content_type)
             .await
@@ -99,6 +115,7 @@ impl NacosConfigService {
         content_type: Option<String>,
         cas_md5: String,
     ) -> crate::api::error::Result<bool> {
+        self.ensure_running()?;
         self.client_worker
             .publish_config_cas(data_id, group, content, content_type, cas_md5)
             .await
@@ -113,6 +130,7 @@ impl NacosConfigService {
         content_type: Option<String>,
         beta_ips: String,
     ) -> crate::api::error::Result<bool> {
+        self.ensure_running()?;
         self.client_worker
             .publish_config_beta(data_id, group, content, content_type, beta_ips)
             .await
@@ -128,6 +146,7 @@ impl NacosConfigService {
         cas_md5: Option<String>,
         params: std::collections::HashMap<String, String>,
     ) -> crate::api::error::Result<bool> {
+        self.ensure_running()?;
         self.client_worker
             .publish_config_param(data_id, group, content, content_type, cas_md5, params)
             .await
@@ -139,6 +158,7 @@ impl NacosConfigService {
         data_id: String,
         group: String,
     ) -> crate::api::error::Result<bool> {
+        self.ensure_running()?;
         self.client_worker.remove_config(data_id, group).await
     }
 
@@ -149,6 +169,7 @@ impl NacosConfigService {
         group: String,
         listener: std::sync::Arc<dyn crate::api::config::ConfigChangeListener>,
     ) -> crate::api::error::Result<()> {
+        self.ensure_running()?;
         self.client_worker
             .add_listener(data_id, group, listener)
             .await;
@@ -162,6 +183,7 @@ impl NacosConfigService {
         group: String,
         listener: std::sync::Arc<dyn crate::api::config::ConfigChangeListener>,
     ) -> crate::api::error::Result<()> {
+        self.ensure_running()?;
         self.client_worker
             .remove_listener(data_id, group, listener)
             .await;

--- a/src/config/worker.rs
+++ b/src/config/worker.rs
@@ -15,12 +15,12 @@ use std::sync::Arc;
 
 use tracing::{Instrument, instrument};
 
-#[derive(Clone)]
 pub(crate) struct ConfigWorker {
     pub(crate) client_props: ClientProps,
     remote_client: Arc<NacosGrpcClient>,
     unified_cache: Arc<Cache<CacheData>>,
     config_filters: Arc<Vec<Box<dyn ConfigFilter>>>,
+    background_tasks: std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>,
 }
 
 impl ConfigWorker {
@@ -34,7 +34,7 @@ impl ConfigWorker {
         // Create unified cache using the Cache framework with CacheData directly
         let unified_cache: Cache<CacheData> = CacheBuilder::config(cache_ns)
             .load_cache_at_start(client_props.get_config_load_cache_at_start())
-            .disk_store()
+            .disk_store(client_props.get_cache_dir())
             .build()
             .await;
         let unified_cache = Arc::new(unified_cache);
@@ -69,6 +69,8 @@ impl ConfigWorker {
             ))
             .auth_plugin(auth_plugin)
             .auth_context(client_props.get_auth_context())
+            .request_timeout(client_props.get_request_timeout())
+            .optional_connect_timeout(client_props.get_connect_timeout())
             .max_retries(client_props.get_max_retries())
             .emergency_start(client_props.get_config_load_cache_at_start())
             .build(client_id)
@@ -76,13 +78,13 @@ impl ConfigWorker {
 
         let remote_client = Arc::new(remote_client);
         // todo Event/Subscriber instead of mpsc Sender/Receiver
-        crate::common::executor::spawn(Self::notify_change_to_cache_data(
+        let notify_task = crate::common::executor::spawn(Self::notify_change_to_cache_data(
             Arc::clone(&remote_client),
             Arc::clone(&unified_cache),
             notify_change_rx,
         ));
 
-        crate::common::executor::spawn(Self::list_ensure_cache_data_newest(
+        let listen_task = crate::common::executor::spawn(Self::list_ensure_cache_data_newest(
             Arc::clone(&remote_client),
             Arc::clone(&unified_cache),
             notify_change_tx_clone,
@@ -93,7 +95,28 @@ impl ConfigWorker {
             remote_client,
             unified_cache,
             config_filters,
+            background_tasks: std::sync::Mutex::new(vec![notify_task, listen_task]),
         })
+    }
+
+    pub(crate) fn is_shutdown(&self) -> bool {
+        self.remote_client.is_shutdown()
+    }
+
+    pub(crate) async fn shutdown(&self) -> crate::api::error::Result<()> {
+        self.remote_client.shutdown().await?;
+        let tasks = {
+            let mut tasks = self
+                .background_tasks
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            std::mem::take(&mut *tasks)
+        };
+        for task in tasks {
+            task.abort();
+            let _ = task.await;
+        }
+        Ok(())
     }
 }
 

--- a/src/config/worker.rs
+++ b/src/config/worker.rs
@@ -21,6 +21,7 @@ pub(crate) struct ConfigWorker {
     unified_cache: Arc<Cache<CacheData>>,
     config_filters: Arc<Vec<Box<dyn ConfigFilter>>>,
     background_tasks: std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>,
+    shutdown_complete: tokio::sync::Mutex<bool>,
 }
 
 impl ConfigWorker {
@@ -96,6 +97,7 @@ impl ConfigWorker {
             unified_cache,
             config_filters,
             background_tasks: std::sync::Mutex::new(vec![notify_task, listen_task]),
+            shutdown_complete: tokio::sync::Mutex::new(false),
         })
     }
 
@@ -104,6 +106,10 @@ impl ConfigWorker {
     }
 
     pub(crate) async fn shutdown(&self) -> crate::api::error::Result<()> {
+        let mut shutdown_complete = self.shutdown_complete.lock().await;
+        if *shutdown_complete {
+            return Ok(());
+        }
         self.remote_client.shutdown().await?;
         let tasks = {
             let mut tasks = self
@@ -116,6 +122,7 @@ impl ConfigWorker {
             task.abort();
             let _ = task.await;
         }
+        *shutdown_complete = true;
         Ok(())
     }
 }

--- a/src/naming/mod.rs
+++ b/src/naming/mod.rs
@@ -93,7 +93,7 @@ impl NacosNamingService {
         // create naming cache
         let naming_cache: Cache<ServiceInfo> = CacheBuilder::naming(namespace.clone())
             .load_cache_at_start(client_props.get_naming_load_cache_at_start())
-            .disk_store()
+            .disk_store(client_props.get_cache_dir())
             .build()
             .await;
         let naming_cache = Arc::new(naming_cache);
@@ -146,6 +146,8 @@ impl NacosNamingService {
             })
             .auth_context(client_props.get_auth_context())
             .auth_plugin(auth_plugin)
+            .request_timeout(client_props.get_request_timeout())
+            .optional_connect_timeout(client_props.get_connect_timeout())
             .max_retries(client_props.get_max_retries())
             .emergency_start(client_props.get_naming_load_cache_at_start())
             .build(client_id.clone())

--- a/tests/it_config.rs
+++ b/tests/it_config.rs
@@ -26,6 +26,7 @@
 //! - `remove_config`
 //! - `add_listener`
 //! - `remove_listener`
+//! - `shutdown`
 //!
 //! Tests require a running Nacos server (rnacos or Docker-based).
 //!
@@ -93,6 +94,34 @@ mod config_integration_tests {
             Ok(_) => tracing::debug!("Cleanup: config removed successfully"),
             Err(e) => tracing::warn!("Cleanup: failed to remove config: {:?}", e),
         }
+    }
+
+    /// Test: shutdown is shared by clones and rejects later requests.
+    #[tokio::test]
+    #[ignore]
+    async fn test_shutdown_is_idempotent_and_shared_by_clones() {
+        crate::shared::setup_log();
+
+        let server_addr = get_shared_server_addr().await;
+        let service = create_config_service(&server_addr).await;
+        let cloned_service = service.clone();
+
+        service
+            .shutdown()
+            .await
+            .expect("first shutdown should succeed");
+        service
+            .shutdown()
+            .await
+            .expect("repeated shutdown should succeed");
+
+        let result = cloned_service
+            .get_config("after-shutdown".to_string(), "DEFAULT_GROUP".to_string())
+            .await;
+        assert!(matches!(
+            result,
+            Err(nacos_sdk::api::error::Error::ClientShutdown(_))
+        ));
     }
 
     /// Test: publish and get config.


### PR DESCRIPTION
Adds:

- ConfigService::shutdown()
- optional request/connect timeouts
- optional cache root

To align the implementation of Golang/Java sdks. Defaults and the existing cache layout are unchanged.