### PR TITLE
fix config notify holding DashMap lock across .await

### DIFF
--- a/src/config/cache.rs
+++ b/src/config/cache.rs
@@ -79,16 +79,24 @@ impl CacheData {
     }
 
     /// Notify listener. when last-md5 not equals the-newest-md5
+    ///
+    /// NOTE: never call while holding a DashMap guard — it awaits (config filters),
+    /// and a guard held across an await can deadlock the SDK runtime.
     pub async fn notify_listener(&mut self) {
+        let config_resp = self.get_config_resp_after_filter().await;
+        self.dispatch_notify(config_resp);
+    }
+
+    /// Dispatch notification synchronously: compare last_md5 and notify in an
+    /// independent task. Never awaits, safe to call while holding a lock.
+    pub(crate) fn dispatch_notify(&self, config_resp: ConfigResponse) {
         tracing::info!(
-            "notify_listener, dataId={},group={},namespace={},md5={}",
+            "dispatch_notify, dataId={},group={},namespace={},md5={}",
             self.data_id,
             self.group,
             self.namespace,
             self.md5
         );
-
-        let config_resp = self.get_config_resp_after_filter().await;
 
         if let Ok(mut mutex) = self.listeners.lock() {
             for listen_wrap in mutex.iter_mut() {
@@ -106,16 +114,27 @@ impl CacheData {
         }
     }
 
-    /// Get config response after applying config_filters
-    pub(crate) async fn get_config_resp_after_filter(&self) -> ConfigResponse {
-        let mut conf_resp = ConfigResp::new(
-            self.data_id.clone(),
-            self.group.clone(),
-            self.namespace.clone(),
-            self.content.clone(),
-            self.encrypted_data_key.clone(),
-        );
-        for config_filter in self.config_filters.iter() {
+    /// Clone a pre-filter response snapshot, so async filters can run lock-free.
+    pub(crate) fn resp_snapshot(&self) -> RespSnapshot {
+        (
+            Arc::clone(&self.config_filters),
+            ConfigResp::new(
+                self.data_id.clone(),
+                self.group.clone(),
+                self.namespace.clone(),
+                self.content.clone(),
+                self.encrypted_data_key.clone(),
+            ),
+            self.content_type.clone(),
+            self.md5.clone(),
+        )
+    }
+
+    /// Apply async config filters to a snapshot. No DashMap guard may be alive.
+    pub(crate) async fn filtered_response(
+        (filters, mut conf_resp, content_type, md5): RespSnapshot,
+    ) -> ConfigResponse {
+        for config_filter in filters.iter() {
             config_filter.filter(None, Some(&mut conf_resp)).await;
         }
 
@@ -124,9 +143,14 @@ impl CacheData {
             conf_resp.group,
             conf_resp.namespace,
             conf_resp.content,
-            self.content_type.clone(),
-            self.md5.clone(),
+            content_type,
+            md5,
         )
+    }
+
+    /// Get config response after applying config_filters
+    pub(crate) async fn get_config_resp_after_filter(&self) -> ConfigResponse {
+        Self::filtered_response(self.resp_snapshot()).await
     }
 }
 
@@ -154,6 +178,9 @@ impl std::fmt::Display for CacheData {
         write!(f, ")")
     }
 }
+
+/// Pre-filter response snapshot: (filters, raw resp, content_type, md5).
+pub(crate) type RespSnapshot = (Arc<Vec<Box<dyn ConfigFilter>>>, ConfigResp, String, String);
 
 /// The inner Wrapper of ConfigChangeListener
 pub(crate) struct ListenerWrapper {
@@ -260,5 +287,189 @@ mod tests {
                 config_resp
             );
         }
+    }
+
+    /// The notify flow must never hold a DashMap guard across an await.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_notify_flow_holds_no_lock_across_await() {
+        use crate::api::plugin::{ConfigFilter, ConfigReq, ConfigResp};
+        use crate::common::cache::{Cache, CacheBuilder};
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+        use std::time::Duration;
+
+        struct BlockingFilter {
+            entered: Arc<AtomicBool>,
+            release: Arc<tokio::sync::Notify>,
+        }
+
+        #[async_trait::async_trait]
+        impl ConfigFilter for BlockingFilter {
+            async fn filter(&self, _: Option<&mut ConfigReq>, _: Option<&mut ConfigResp>) {
+                self.entered.store(true, Ordering::Release);
+                self.release.notified().await;
+            }
+        }
+
+        struct CountingListener {
+            hits: AtomicUsize,
+        }
+
+        impl ConfigChangeListener for CountingListener {
+            fn notify(&self, _: ConfigResponse) {
+                self.hits.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let entered = Arc::new(AtomicBool::new(false));
+        let release = Arc::new(tokio::sync::Notify::new());
+        let filters: Arc<Vec<Box<dyn ConfigFilter>>> = Arc::new(vec![Box::new(BlockingFilter {
+            entered: Arc::clone(&entered),
+            release: Arc::clone(&release),
+        })]);
+
+        let cache: Arc<Cache<CacheData>> =
+            Arc::new(CacheBuilder::config("test-ns".to_string()).build().await);
+        let key = "D+G+test-ns".to_string();
+        let listener = Arc::new(CountingListener {
+            hits: AtomicUsize::new(0),
+        });
+
+        let mut data = CacheData::new(
+            filters,
+            "D".to_string(),
+            "G".to_string(),
+            "test-ns".to_string(),
+        );
+        data.content = "c".to_string();
+        data.md5 = "m1".to_string();
+        data.initializing = false;
+        data.add_listener(listener.clone());
+        cache.insert(key.clone(), data);
+
+        // Mirror the worker's notify path: snapshot under a short read guard,
+        // run async filters lock-free, then dispatch synchronously.
+        let cache_in_task = Arc::clone(&cache);
+        let key_in_task = key.clone();
+        let notify_task = tokio::spawn(async move {
+            let snapshot = cache_in_task
+                .get(&key_in_task)
+                .map(|r| r.resp_snapshot())
+                .expect("entry should exist");
+            let resp = CacheData::filtered_response(snapshot).await;
+            if let Some(r) = cache_in_task.get(&key_in_task) {
+                r.dispatch_notify(resp);
+            }
+        });
+
+        // Wait until the filter is in-flight; the read guard must already be dropped.
+        while !entered.load(Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+
+        // While the notify flow is suspended, the entry must stay writable...
+        tokio::time::timeout(Duration::from_millis(200), async {
+            let mut w = cache.get_mut(&key).expect("entry should exist");
+            w.last_modified = 42;
+        })
+        .await
+        .expect("get_mut blocked: a cache lock is held across an await");
+
+        // ...and iterable (this is what list_ensure_cache_data_newest does).
+        tokio::time::timeout(Duration::from_millis(200), async {
+            let mut n = 0;
+            cache.for_each(|_, _| n += 1);
+            assert_eq!(1, n);
+        })
+        .await
+        .expect("for_each blocked: a cache lock is held across an await");
+
+        // Release the filter; the listener must be notified and last_md5 updated.
+        release.notify_one();
+        tokio::time::timeout(Duration::from_secs(2), notify_task)
+            .await
+            .expect("notify task stuck")
+            .expect("notify task panicked");
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while listener.hits.load(Ordering::SeqCst) == 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("listener was not notified");
+
+        let r = cache.get(&key).expect("entry should exist");
+        let last_md5 = r.listeners.lock().expect("mutex should not be poisoned")[0]
+            .last_md5
+            .clone();
+        assert_eq!("m1", last_md5);
+    }
+
+    /// A write guard held across an await blocks all access to the shard.
+    /// Pinned here as the failure mode the notify flow must avoid.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_guard_across_await_blocks_cache() {
+        use crate::common::cache::{Cache, CacheBuilder};
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::time::Duration;
+
+        let cache: Arc<Cache<CacheData>> =
+            Arc::new(CacheBuilder::config("test-ns".to_string()).build().await);
+        let key = "D+G+test-ns".to_string();
+        cache.insert(
+            key.clone(),
+            CacheData::new(
+                Arc::new(Vec::new()),
+                "D".to_string(),
+                "G".to_string(),
+                "test-ns".to_string(),
+            ),
+        );
+
+        let entered = Arc::new(AtomicBool::new(false));
+        let release = Arc::new(tokio::sync::Notify::new());
+        let holder = {
+            let cache = Arc::clone(&cache);
+            let key = key.clone();
+            let entered = Arc::clone(&entered);
+            let release = Arc::clone(&release);
+            tokio::spawn(async move {
+                let _guard = cache.get_mut(&key); // guard held...
+                entered.store(true, Ordering::Release);
+                release.notified().await; // ...across an await
+            })
+        };
+
+        while !entered.load(Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+
+        // Iterating the shard must now block. Runs on the blocking pool so the
+        // test's own single worker stays free to time out and recover.
+        let iter = {
+            let cache = Arc::clone(&cache);
+            tokio::task::spawn_blocking(move || cache.for_each(|_, _| {}))
+        };
+        let blocked = tokio::time::timeout(Duration::from_millis(200), iter)
+            .await
+            .is_err();
+        assert!(
+            blocked,
+            "for_each should block while a write guard is held across an await"
+        );
+
+        // After the guard drops, iteration recovers.
+        release.notify_one();
+        tokio::time::timeout(Duration::from_secs(2), holder)
+            .await
+            .expect("guard holder stuck")
+            .expect("guard holder panicked");
+        tokio::time::timeout(Duration::from_secs(2), async {
+            let mut n = 0;
+            cache.for_each(|_, _| n += 1);
+            assert_eq!(1, n);
+        })
+        .await
+        .expect("for_each still blocked after guard dropped");
     }
 }

--- a/src/config/worker.rs
+++ b/src/config/worker.rs
@@ -108,12 +108,16 @@ impl ConfigWorker {
         let group_key = util::group_key(&data_id, &group, &namespace);
 
         // Try to get config from cache first (if cache exists and content is complete)
-        if let Some(cache_ref) = self.unified_cache.get(&group_key) {
-            // Check if cache has complete content (not empty and has md5)
-            if !cache_ref.content.is_empty() && !cache_ref.md5.is_empty() {
-                tracing::info!("get_config from cache, group_key={}", group_key);
-                return Ok(cache_ref.get_config_resp_after_filter().await);
+        let cached_snapshot = self.unified_cache.get(&group_key).and_then(|r| {
+            if !r.content.is_empty() && !r.md5.is_empty() {
+                Some(r.resp_snapshot())
+            } else {
+                None
             }
+        });
+        if let Some(snapshot) = cached_snapshot {
+            tracing::info!("get_config from cache, group_key={}", group_key);
+            return Ok(CacheData::filtered_response(snapshot).await);
         }
 
         // Cache miss or incomplete content, fetch from server
@@ -403,7 +407,9 @@ impl ConfigWorker {
         }
     }
 
-    async fn fill_data_and_notify(cache_data: &mut CacheData, config_resp: ConfigQueryResponse) {
+    /// Synchronously fill fields from the response; returns whether listeners should
+    /// be notified (the first fill during initialization does not notify).
+    fn fill_data(cache_data: &mut CacheData, config_resp: ConfigQueryResponse) -> bool {
         cache_data.content_type = config_resp
             .content_type
             .expect("Config content_type missing in response");
@@ -414,10 +420,17 @@ impl ConfigWorker {
         // Compatibility None < 2.1.0
         cache_data.encrypted_data_key = config_resp.encrypted_data_key.unwrap_or_default();
         cache_data.last_modified = config_resp.last_modified;
-        tracing::info!("fill_data_and_notify, cache_data={}", cache_data);
+        tracing::info!("fill_data, cache_data={}", cache_data);
         if cache_data.initializing {
             cache_data.initializing = false;
+            false
         } else {
+            true
+        }
+    }
+
+    async fn fill_data_and_notify(cache_data: &mut CacheData, config_resp: ConfigQueryResponse) {
+        if Self::fill_data(cache_data, config_resp) {
             // check md5 and then notify
             cache_data.notify_listener().await;
         }
@@ -439,23 +452,46 @@ impl ConfigWorker {
                     break;
                 }
                 Some(group_key) => {
-                    if let Some(mut cache_ref_mut) = unified_cache.get_mut(&group_key) {
-                        // get the newest config to notify
-                        let config_resp = Self::get_config_inner_async(
-                            remote_client.clone(),
-                            cache_ref_mut.data_id.clone(),
-                            cache_ref_mut.group.clone(),
-                            cache_ref_mut.namespace.clone(),
-                        )
-                        .in_current_span()
-                        .await;
-                        match config_resp {
-                            Ok(config_resp) => {
-                                Self::fill_data_and_notify(&mut cache_ref_mut, config_resp).await;
+                    // A DashMap guard must never live across an .await: the suspended
+                    // future would hold the shard lock indefinitely and freeze the
+                    // single-worker SDK runtime.
+                    let snapshot = unified_cache
+                        .get(&group_key)
+                        .map(|r| (r.data_id.clone(), r.group.clone(), r.namespace.clone()));
+                    let Some((data_id, group, namespace)) = snapshot else {
+                        continue;
+                    };
+
+                    let config_resp = Self::get_config_inner_async(
+                        remote_client.clone(),
+                        data_id,
+                        group,
+                        namespace,
+                    )
+                    .in_current_span()
+                    .await;
+
+                    match config_resp {
+                        Ok(config_resp) => {
+                            let should_notify = match unified_cache.get_mut(&group_key) {
+                                Some(mut cache_ref_mut) => {
+                                    Self::fill_data(&mut cache_ref_mut, config_resp)
+                                }
+                                None => false,
+                            };
+                            if should_notify {
+                                let snapshot =
+                                    unified_cache.get(&group_key).map(|r| r.resp_snapshot());
+                                if let Some(snapshot) = snapshot {
+                                    let resp = CacheData::filtered_response(snapshot).await;
+                                    if let Some(cache_ref) = unified_cache.get(&group_key) {
+                                        cache_ref.dispatch_notify(resp);
+                                    }
+                                }
                             }
-                            Err(e) => {
-                                tracing::error!("get_config_inner_async, config_resp err={e:?}");
-                            }
+                        }
+                        Err(e) => {
+                            tracing::error!("get_config_inner_async, config_resp err={e:?}");
                         }
                     }
                 }


### PR DESCRIPTION
Fixes: #309

## Problem

See #309 for the full analysis. In short: the config notify flow held a DashMap guard across `.await` points, so a stalled RPC or config filter could freeze the SDK runtime. The `get_config` cache-hit path had the same pattern in weaker form (a read guard held across the async filter call).

## Changes

- Restructured the notify flow so no DashMap guard is held across an `.await`: short guards for synchronous field reads/writes; the RPC and async filters run lock-free; listener dispatch stays synchronous.
- Split `fill_data_and_notify` into a synchronous `fill_data` plus a separate notification step (`dispatch_notify`), with a `resp_snapshot()` / `filtered_response()` pair for the lock-free filter stage.
- Applied the same snapshot-first pattern to the `get_config` cache-hit path.
- Listener-visible behavior is unchanged: same fill/notify semantics, same md5 comparison, same callbacks.

## Test plan

Two new unit tests, no server required; a gated `ConfigFilter` simulates a suspended await:

- `config::cache::tests::test_guard_across_await_blocks_cache` — pins the failure mode this PR avoids: a write guard held across an await blocks shard iteration, and access recovers once the guard drops.
- `config::cache::tests::test_notify_flow_holds_no_lock_across_await` — the fixed notify flow keeps `get_mut`/`for_each` responsive while the filter is suspended; after release the listener is notified and `last_md5` updates correctly.

All existing unit tests pass (`cargo test --lib`), clippy is clean.

## Notes

- `ConfigQueryRequest` currently has no request-level timeout, so a hung RPC can still stall the notification queue (including changes to other keys) until the RPC returns or the connection is declared dead — but it no longer holds any lock, so cache reads and all other SDK duties stay responsive. If you think it's useful, I'm happy to follow up with a request-level timeout in a separate PR.
